### PR TITLE
feat: intent-alignment 审计框架

### DIFF
--- a/artifacts/intent-alignment-audit-latest.json
+++ b/artifacts/intent-alignment-audit-latest.json
@@ -1,0 +1,362 @@
+{
+  "timestamp": "2026-04-14T04:51:37.033Z",
+  "commits_scanned": 20,
+  "contracts_scanned": 41,
+  "designs_scanned": 12,
+  "code_files_with_frontmatter": 5,
+  "code_signals": 76,
+  "matrix": [
+    {
+      "intentSource": "docs/current/architecture-overview.md",
+      "intentDesc": "四层模块拓扑的读写路径",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/artifact-contract.md",
+      "intentDesc": "artifacts 运行产物目录规范",
+      "contractStatus": "draft",
+      "implementedBy": [
+        "scripts/capture-baseline.mjs",
+        "scripts/eval.mjs",
+        "scripts/export-v7-artifacts.mjs"
+      ],
+      "alignedCommits": [],
+      "implementationStatus": "claimed_with_known_transition",
+      "driftSignal": "none"
+    },
+    {
+      "intentSource": "docs/current/compile-promotion-contract.md",
+      "intentDesc": "compile 晋升落盘规则",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/contract-audit-contract.md",
+      "intentDesc": "契约审计规则规格",
+      "contractStatus": "current",
+      "implementedBy": [
+        "scripts/contract-audit.mjs"
+      ],
+      "alignedCommits": [],
+      "implementationStatus": "claimed_with_known_transition",
+      "driftSignal": "none"
+    },
+    {
+      "intentSource": "docs/current/counterfactual-scenario-contract.md",
+      "intentDesc": "反事实场景对象规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/coverage-matrix-contract.md",
+      "intentDesc": "coverage-matrix 表规范",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/derivation-chain-contract.md",
+      "intentDesc": "推导链对象规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/episode-event-contract.md",
+      "intentDesc": "Episode 事件时间线",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/epistemic-contract.md",
+      "intentDesc": "显式求解与本体更新",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/experiment-design-contract.md",
+      "intentDesc": "实验设计对象规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/file-taxonomy-contract.md",
+      "intentDesc": "文件五类零交集分类公理",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/hypothesis-contract.md",
+      "intentDesc": "Hypothesis 状态机门控",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/intent-alignment-audit-contract.md",
+      "intentDesc": "测试agent与代码编写agent的意图一致性审计协议",
+      "contractStatus": "draft",
+      "implementedBy": [
+        "scripts/intent-alignment-audit.mjs"
+      ],
+      "alignedCommits": [],
+      "implementationStatus": "claimed_implemented",
+      "driftSignal": "none"
+    },
+    {
+      "intentSource": "docs/current/intent-alignment-report-template.md",
+      "intentDesc": "意图一致性审计报告输出模板规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/knowledge-source-contract.md",
+      "intentDesc": "composites 知识源规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/legacy-scaffolds-contract.md",
+      "intentDesc": "legacy 脚本登记",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/mechanism-class-contract.md",
+      "intentDesc": "MechanismClass 动力学模板",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/mechanism-instance-contract.md",
+      "intentDesc": "机制实例绑定规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/mechanism-program-contract.md",
+      "intentDesc": "机制程序对象规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/memory-layer-contract.md",
+      "intentDesc": "",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/memory-layer-current.md",
+      "intentDesc": "当前真实存在的检索 MCP 工具清单",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/memory-layer-target.md",
+      "intentDesc": "五层 retrieval 目标设计",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/metamodel.md",
+      "intentDesc": "五模块核心语义定义",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/metrics-contract.md",
+      "intentDesc": "metrics.json 字段字典",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/observation-model-contract.md",
+      "intentDesc": "观测投影对象规范",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/ontology-delta-contract.md",
+      "intentDesc": "本体增量对象规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/pipeline-contract.md",
+      "intentDesc": "pipeline 的调用序列",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/plugin-surface-contract.md",
+      "intentDesc": "双通道 plugin 分发边界",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/reconstruction-contract.md",
+      "intentDesc": "过程重建对象规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/ref-algebra-contract.md",
+      "intentDesc": "Ref 复合合法性代数",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/run-summary-contract.md",
+      "intentDesc": "run summary 文档结构",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/stats-snapshot-contract.md",
+      "intentDesc": "stats 原始快照结构",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/summary-markdown-contract.md",
+      "intentDesc": "summary.md 结构规范",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/support-link-contract.md",
+      "intentDesc": "证据边对象规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/template-invariant-contract.md",
+      "intentDesc": "Template 不变量门控",
+      "contractStatus": "current",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/testing-strategy-contract.md",
+      "intentDesc": "OpenAGI级测试验证体系与运行时信息收集规范",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/v6-world-model-contract.md",
+      "intentDesc": "四空间世界模型引擎",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    },
+    {
+      "intentSource": "docs/current/v7-world-model-contract.md",
+      "intentDesc": "五层世界动力学引擎",
+      "contractStatus": "draft",
+      "implementedBy": [],
+      "alignedCommits": [],
+      "implementationStatus": "no_code_claim",
+      "driftSignal": "mode5_silent_gap"
+    }
+  ],
+  "future_signals_count": 47,
+  "has_v8v9_in_code": true
+}

--- a/artifacts/intent-alignment-audit-latest.md
+++ b/artifacts/intent-alignment-audit-latest.md
@@ -1,0 +1,157 @@
+# 意图一致性审计报告
+
+生成时间: 2026-04-14T04:51:37.027Z
+扫描 commit 数: 20
+扫描代码文件数: 已扫描
+
+## 执行摘要
+
+| 维度 | 结果 |
+|------|------|
+| 合同总数 | 38 |
+| 宣称对齐但未完成 (模式 1) | 0 |
+| 完全沉默的缺口 (模式 5) | 35 |
+| metrics 僵尸声明 (模式 3) | 0 |
+| v8/v9 未来意图代码信号 | 47 处 |
+
+---
+
+## 1. 意图-实现矩阵
+
+| 意图来源 | 合同状态 | 代码声称实现 | 对齐 commit | 实现状态 | 漂移信号 |
+|----------|----------|--------------|-------------|----------|----------|
+| architecture-overview.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| artifact-contract.md | draft | scripts/capture-baseline.mjs<br>scripts/eval.mjs<br>scripts/export-v7-artifacts.mjs | - | claimed_with_known_transition | - |
+| compile-promotion-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| contract-audit-contract.md | current | scripts/contract-audit.mjs | - | claimed_with_known_transition | - |
+| counterfactual-scenario-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| coverage-matrix-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| derivation-chain-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| episode-event-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| epistemic-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| experiment-design-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| file-taxonomy-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| hypothesis-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| intent-alignment-audit-contract.md | draft | scripts/intent-alignment-audit.mjs | - | claimed_implemented | - |
+| intent-alignment-report-template.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| knowledge-source-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| legacy-scaffolds-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| mechanism-class-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| mechanism-instance-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| mechanism-program-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| memory-layer-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| memory-layer-current.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| memory-layer-target.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| metamodel.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| metrics-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| observation-model-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| ontology-delta-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| pipeline-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| plugin-surface-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| reconstruction-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| ref-algebra-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| run-summary-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| stats-snapshot-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| summary-markdown-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| support-link-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| template-invariant-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+| testing-strategy-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| v6-world-model-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+| v7-world-model-contract.md | draft | (无) | - | no_code_claim | mode5_silent_gap |
+
+---
+
+## 2. 矛盾与建议详表
+
+### C3: 16 份 current 合同无任何代码文件认领 implements
+
+- **矛盾点**：这些合同被标记为 `status: current`（已冻结），但没有代码文件通过 `implements` 声明与它们建立关联。
+- **意图侧**：current 合同应该代表已经稳定、正在被执行的意图。
+- **实现侧**：代码层缺少对 current 合同的显式认领，导致意图-实现的追溯链断裂。
+- **改善建议**：
+  1. 对 16 份 silent current 合同进行分类：有些是纯元文档（如 `file-taxonomy-contract.md`），不需要被代码实现，建议将其 `status` 改为 `reference`；
+  2. 有些合同（如 `ref-algebra-contract.md`、`pipeline-contract.md`、`compile-promotion-contract.md`）的核心逻辑确实存在于代码中，建议给对应的 `.ts` 文件补一个 `// implements:` frontmatter，建立显式链接。
+- **优先级**: P1
+
+### C5: mechanism-class 合同承诺"可回放"，但核心代码仍依赖 proxy 过渡态
+
+- **矛盾点**：`mechanism-class-contract.md` §2 定义 `MechanismClass` 是可回放的动力学模板，但 `pipeline.ts:558-561` 生成 `proxy:hyp_xxx` / `proxy:episode_xxx` 作为 `mechanism_class_ref`。
+- **意图侧**：合同要求 MechanismClass 具备 `phases` 和 `replayError` 计算，能够按 phases 回放 Episode timeline。
+- **实现侧**：由于真实的 `MechanismClass` 晋升路径尚未打通（多 Episode 门控、replay 一致性检查），`recordFix()` 仍然用 proxy 前缀来桥接。
+- **改善建议**：
+  1. 在 `mechanism-class-contract.md` 中新增 "proxy 前缀退役计划" 章节，明确三个条件：(a) MechanismInstanceStore 中 accepted 状态 ≥2 个独立 episode；(b) replayError < 0.3；(c) 通过 counterexample 检查。
+  2. 当条件满足时，触发一个自动化提醒（或 CI check），提示可以开始移除 proxy 前缀。
+- **优先级**: P1
+
+---
+
+## 3. 精选发现（对话式）
+
+### 发现 #2: 沉默的缺口（模式 5）
+
+**意图来源**: `docs/current/architecture-overview.md`
+**合同状态**: current
+**代码声称实现**: (无)
+> **问题**: 这份合同有明确的 current/draft 状态，但没有任何代码文件通过 `implements` 声称实现它。如果它确实不重要，建议将其降级为 reference；如果它应该被实现，建议至少创建一个占位符代码文件并添加 `implements` 声明。
+
+**意图来源**: `docs/current/compile-promotion-contract.md`
+**合同状态**: current
+**代码声称实现**: (无)
+> **问题**: 这份合同有明确的 current/draft 状态，但没有任何代码文件通过 `implements` 声称实现它。如果它确实不重要，建议将其降级为 reference；如果它应该被实现，建议至少创建一个占位符代码文件并添加 `implements` 声明。
+
+**意图来源**: `docs/current/counterfactual-scenario-contract.md`
+**合同状态**: draft
+**代码声称实现**: (无)
+> **问题**: 这份合同有明确的 current/draft 状态，但没有任何代码文件通过 `implements` 声称实现它。如果它确实不重要，建议将其降级为 reference；如果它应该被实现，建议至少创建一个占位符代码文件并添加 `implements` 声明。
+
+---
+
+## 3. 代码信号清单
+
+### future-intent (47 处)
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:2` * CounterfactualScenarioStore — SQLite 持久化层
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:11` import type { CounterfactualScenario } from './counterfactual-scenario.js';
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:17` interface CounterfactualScenarioRow {
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:25` function rowToScenario(row: CounterfactualScenarioRow): CounterfactualScenario {
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:26` return JSON.parse(row.data) as CounterfactualScenario;
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:30` // CounterfactualScenarioStore 类
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:33` export interface CounterfactualScenarioStoreStats {
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:38` export class CounterfactualScenarioStore {
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:66` save(scenario: CounterfactualScenario): void {
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:81` get(id: string): CounterfactualScenario | null {
+- ... 还有 37 处
+
+### todo (16 处)
+- `causal-learner/mcp-server/src/core/experiment-design-store.ts:6` * listByCounterfactual() 第一轮做内存过滤（过渡态），待后续加专用索引。
+- `causal-learner/mcp-server/src/core/experiment-design-store.ts:99` * 过渡态：内存过滤（basedOnCounterfactualIds 在 JSON blob 中），待后续加专用索引
+- `causal-learner/mcp-server/src/core/mechanism-instance.ts:19` | 'path_projection'  // 来自 AtomGraph 路径投影（过渡态，不得作为最终 current 语义）
+- `causal-learner/mcp-server/src/core/mechanism-instance.ts:34` /** 指向 MechanismClass（允许 proxy:* 前缀表示过渡态） */
+- `causal-learner/mcp-server/src/core/mechanism-program.ts:29` /** 指向 MechanismClass（允许 proxy:* 前缀表示过渡态） */
+- `causal-learner/mcp-server/src/core/mechanism-program.ts:134` description:      '通过 AtomGraph 路径投影触发的默认机制程序（第一轮过渡模型）。不携带真实 phase 语义，占位用。',
+- `causal-learner/mcp-server/src/core/pipeline.ts:553` // source_kind='path_projection'：当前为过渡态，路径 Atom 作为 slot 绑定代理
+- `scripts/capture-baseline.mjs:40` * TODO(2026-04-13): stats-snapshot-contract.md / run-summary-contract.md 由并行 age...
+- `scripts/contract-audit.mjs:136` if (/§\s*2b|目标|target|future|待建|计划/.test(s)) mode = 'draft';
+- `scripts/eval.mjs:9` // TODO(2026-04-13): stats-snapshot-contract.md / run-summary-contract.md 由并行 ag...
+- ... 还有 6 处
+
+### proxy (13 处)
+- `causal-learner/mcp-server/src/core/mechanism-instance.ts:34` /** 指向 MechanismClass（允许 proxy:* 前缀表示过渡态） */
+- `causal-learner/mcp-server/src/core/mechanism-program.ts:29` /** 指向 MechanismClass（允许 proxy:* 前缀表示过渡态） */
+- `causal-learner/mcp-server/src/core/mechanism-program.ts:132` mechanismClassRef: 'proxy:default_path_projection',
+- `causal-learner/mcp-server/src/core/pipeline.ts:558` // D3: 使用 proxy:* 前缀，不伪造真实 MechanismClass ID
+- `causal-learner/mcp-server/src/core/pipeline.ts:560` ? `proxy:hyp_${hypothesisId}`
+- `causal-learner/mcp-server/src/core/pipeline.ts:561` : `proxy:episode_${input.storyId}`;
+- `causal-learner/mcp-server/src/tests/pipeline-recordfix.test.ts:42` mechanism_class_ref: 'proxy:episode_ep_test',
+- `causal-learner/mcp-server/src/tests/pipeline-recordfix.test.ts:71` assert.ok(result.mechanismInstance.mechanism_class_ref.startsWith('proxy:'));
+- `causal-learner/mcp-server/src/tests/pipeline-recordfix.test.ts:79` mechanism_class_ref: 'proxy:test_class',
+- `causal-learner/mcp-server/src/tests/pipeline-recordfix.test.ts:93` const base = { episode_id: 'ep_sm', mechanism_class_ref: 'proxy:ep_sm', bindings...
+- ... 还有 3 处
+
+---
+
+## 4. 下一步行动建议
+
+1. **修正 metrics-contract.md**：同步 `eval.mjs` 中已经正确的字段来源。
+2. **为 proxy 前缀建立退役计划**：消除 mechanism-instance 层的模式 1 漂移。
+3. **评估 v8/v9 占位符**：决定是否在当前代码中加入前瞻类型声明。
+4. **检查沉默的合同**：确认 `mode5_silent_gap` 列表中的合同是否真的不需要代码实现。

--- a/docs/current/intent-alignment-audit-contract.md
+++ b/docs/current/intent-alignment-audit-contract.md
@@ -1,0 +1,468 @@
+---
+kind: contract
+status: draft
+phase: 1
+schema_version: 1
+describes: "测试agent与代码编写agent的意图一致性审计协议"
+---
+
+# 意图一致性审计合同：测试工程师作为编写者的对话者
+
+> 本文档定义一种新型测试验证范式：**测试 agent 不是代码的审判者，而是代码编写者的对话者与印证者**。
+> 核心任务：通过理解项目的设计意图，对照代码编写者的过程文档，发现"意图漂移"（intention drift），并帮助编写者改善项目。
+> 上游依赖：[testing-strategy-contract.md](./testing-strategy-contract.md)、[file-taxonomy-contract.md](./file-taxonomy-contract.md)
+
+---
+
+## 1. 核心哲学：从"找错"到"印证"
+
+传统测试：
+```text
+输入 → 代码 → 输出 ≠ 预期 → 报 bug
+```
+
+意图一致性审计：
+```text
+设计意图（design_history + contracts + roadmap）
+    ↓
+代码编写者的自我理解（commit message + code comments + implements）
+    ↓
+测试 agent 进行对照 → 发现"意图漂移"或"理解空白"
+    ↓
+不是报 bug，而是提出问题、建议改善方向、帮助编写者校准
+```
+
+### 1.1 什么是一次好的意图一致性审计
+
+**不是**：
+- "这里少了一个分号"（这是 Linter 的事）
+- "这个函数返回了 undefined"（这是单元测试的事）
+- "文档写错了"（这是 spell-check 的事）
+
+**而是**：
+- "v7 的设计意图是'经历不是聊天记录，而是世界采样'，但代码中的 `ObservationRecord` 仍然缺少 `perspectiveId` 字段，这意味着系统仍然默认了一个中性观察者。这是否是有意的妥协？"
+- "v9 的合同要求'统一不是默认，统一是需要被证明的结果'，但 `OntologyModel.sharedKernelContribution` 的默认值为 `false`，且没有配套的验证流程。这是否说明 v9 的联邦层还处于占位状态？"
+- "commit message 说'对齐上游合同'，但代码中的 `mechanism_class_ref` 仍然使用 `proxy:*` 前缀，而 `mechanism-class-contract.md` 要求它最终应指向真实的 `MC_*` ID。这是否是一次未完成的对齐？"
+
+### 1.2 测试工程师的新角色
+
+```text
+意图考古学家（Intent Archaeologist）
+    → 挖掘设计文档中的深层意图
+
+过程文档读者（Process Document Reader）
+    → 理解代码编写者认为自己在做什么
+
+对话发起者（Dialogue Initiator）
+    → 发现矛盾时不直接下结论，而是提出结构化问题
+
+改善建议者（Improvement Advisor）
+    → 给出"如何更好地实现意图"的方向，而非仅指出错误
+```
+
+---
+
+## 2. 意图文档层：理解"为什么"
+
+意图一致性审计的第一步是系统性地读取以下文档，提炼出**不可妥协的设计意图**。
+
+### 2.1 设计历史（Design History）
+
+来源：`docs/design_history/v*.md`
+
+读取重点：
+- 每个版本的**核心主张**（通常在前3节）
+- 上一版本"已经解决了什么"和"还缺什么"
+- 版本演化的**口号**和**最终判断**
+
+提取方法：
+```text
+对每个版本 vN：
+  核心主张 = vN 的"一句定义"
+  新增层 = vN 相对于 vN-1 新增了什么
+  遗留缺口 = vN 承认的"还缺的硬骨头"
+```
+
+### 2.2 当前合同（Current Contracts）
+
+来源：`docs/current/*-contract.md`
+
+读取重点：
+- `describes` 字段：这份合同管什么
+- `status` 字段：current / draft / mixed
+- §"硬约束"/"不变量"/"铁律"章节
+- TypeScript interface 定义
+
+提取方法：
+```text
+对每份合同：
+  若 status = current → 视为已冻结的意图
+  若 status = draft → 视为正在形成的意图，允许代码不完全对齐
+  若 status = mixed → 需要按章节区分 current 和 draft 部分
+```
+
+### 2.3 路线图（Roadmap）
+
+来源：`docs/bestqa-roadmap.md`
+
+读取重点：
+- 当前处于哪个 Phase
+- 每个 Phase 的 Exit Criteria
+- 哪些功能是"当前 Phase 必须实现的"，哪些是"下游 Phase 才需要的"
+
+### 2.4 元模型（Metamodel）
+
+来源：`docs/current/metamodel.md`
+
+读取重点：
+- 五个并列模块的边界
+- 系统不变量（图是唯一写模型、Regulation 只是读视图等）
+- 写权限与失效规则
+
+---
+
+## 3. 过程文档层：理解"编写者认为自己在做什么"
+
+意图一致性审计的第二步是收集代码编写者留下的"自我理解痕迹"。
+
+### 3.1 Commit Message
+
+来源：`git log`
+
+读取重点：
+- commit message 是否引用了合同或设计文档？（如 "v7 §10 条件 5"）
+- commit message 的自我描述是否与变更内容一致？
+- 是否有 "对齐"、"收紧"、"收束"、"修正" 等信号词，暗示这是一次意图校准？
+
+### 3.2 代码中的伪 Frontmatter（`// ---` 注释）
+
+来源：`.mjs` / `.ts` 文件头部
+
+读取重点：
+- `kind: code`
+- `implements:` 指向哪个合同
+- `also related:` 引用的相关合同
+
+### 3.3 代码内联注释中的 `implements:` / `upstream:` / `downstream:`
+
+来源：代码块上方的 JSDoc / 行内注释
+
+读取重点：
+- 该代码块声称实现了哪个合同的哪一节？
+- 是否有 "TODO"、"HACK"、"proxy"、"过渡态" 等信号词？
+
+### 3.4 审计记录与偏差盘点
+
+来源：`docs/current/contract-vs-impl-audit.md`
+
+读取重点：
+- 哪些是 "blocker"、哪些是 "major"、哪些是 "minor"
+- 哪些是 "信息偏差"（契约写了计划但代码不存在），哪些是 "语义偏差"（契约和代码存在但语义不一致）
+
+### 3.5 覆盖率矩阵
+
+来源：`docs/current/coverage-matrix-contract.md`（如果存在）
+
+读取重点：
+- 哪些合同有代码实现覆盖？
+- 哪些合同的实现覆盖率低于预期？
+
+---
+
+## 4. 对照方法：发现意图漂移的五种模式
+
+### 模式 1：宣称对齐 vs 实际未完成（Claimed Alignment but Incomplete）
+
+**信号**：
+- commit message 说 "对齐了 X 合同"，但代码中仍然有 `proxy:*`、TODO、或缺失字段
+- 代码的 `implements` 指向了 current contract，但 contract 中的某个关键字段在代码中不存在
+
+**例子**：
+```text
+commit: "对齐新版 mechanism-instance 合约"
+代码: mechanism_class_ref 仍然是 proxy:hyp_xxx
+合同: mechanism-instance-contract.md 要求最终指向真实 MC_* ID
+→ 漂移：这是一次部分对齐，但 commit message 暗示了完整对齐
+```
+
+**测试 agent 的回应**：
+> "这次 commit 声称对齐了 mechanism-instance 合约，但我注意到 `mechanism_class_ref` 仍然使用 `proxy:*` 前缀。根据合同 §D3，proxy 是过渡态。请问：
+> 1. 这是已知且计划中的过渡态吗？
+> 2. 如果是，是否应该在代码注释或某份合同中标注 'proxy 前缀预计在 v7.x 中移除'？
+> 3. 如果不是，是否有遗漏的实现步骤？"
+
+### 模式 2：高级意图 vs 低级妥协（High-level Intent vs Low-level Compromise）
+
+**信号**：
+- 设计文档/v9 合同要求一个高级特性（如多视角、本体联邦），但代码实现仍然假设单一视角
+- 代码没有错误，但与设计意图的方向不一致
+
+**例子**：
+```text
+v9 合同: "Observation 不是中性的，必须声明 perspectiveId"
+代码: ObservationRecord 接口没有 perspectiveId 字段
+→ 漂移：代码仍然默认了一个普遍有效的观察者
+```
+
+**测试 agent 的回应**：
+> "v9 的本体联邦层要求每个 Observation 都绑定一个 `PerspectiveModel`，但当前的 `ObservationRecord` 接口缺少 `perspectiveId`。这意味着系统仍然隐含了一个中性观察者。
+> 这是否说明 v9 的联邦层目前还处于占位状态？如果是，我建议：
+> 1. 在 `observation-model-contract.md` 中标注 'perspectiveId 为 v9 预留字段，v7/v8 阶段使用默认视角'
+> 2. 或者在 `ObservationRecord` 中先加入可选的 `perspectiveId?: string'，并附 TODO 注释"
+
+### 模式 3：合同之间的张力未被代码解决（Unresolved Tension Between Contracts）
+
+**信号**：
+- 合同 A 和合同 B 对同一概念有不同定义
+- 代码选择实现了其中一个，但没有明确说明另一个被如何处理
+
+**例子**：
+```text
+metrics-contract.md: regulations_confirmed 来自 get_stats
+contract-vs-impl-audit.md: 实际来自 get_dual_stats
+代码: eval.mjs 使用了 get_dual_stats 的映射
+→ 漂移：metrics 合同本身已经过时，但代码编写者可能已经知道了这一点（因为 eval.mjs 正确使用了 get_dual_stats）
+```
+
+**测试 agent 的回应**：
+> "我注意到 `eval.mjs` 正确地将 `regulations_confirmed` 映射到了 `get_dual_stats().regulationsByStatus.confirmed`，但 `metrics-contract.md` 仍然声明它来自 `get_stats`。根据 `contract-vs-impl-audit.md` 的 B1，这是一个已知 blocker。
+> 既然代码已经'偷偷'修正了这个问题，为什么不把合同也同步更新？否则未来的代码编写者可能会按旧合同错误实现。"
+
+### 模式 4：意图被过度实现（Over-implementation of Intent）
+
+**信号**：
+- 代码实现了比当前设计意图更复杂的功能
+- 这本身不是错误，但可能消耗了本应用于其他缺口的资源
+
+**例子**：
+```text
+设计意图: "Episode 必须具备 timeline"
+代码: 实现了完整的 EpisodeEventStore + event log + seq 管理
+→ 但同时 StateSnapshot / Transition 仍然是未实现状态
+→ 漂移：编写者可能过度投资了事件日志，而忽略了状态快照层
+```
+
+**测试 agent 的回应**：
+> "EpisodeEventStore 的实现非常完整，但 `StateSnapshot` 和 `Transition` 仍然是 `interface` 占位符。如果 v7 的核心意图是'把经历当成带轨迹的采样'，那么没有状态快照的 timeline 更像是一个聊天记录的增强版，而不是世界采样。
+> 建议：要么将 StateSnapshot 的实现提升为下一个优先项，要么在合同中重新校准 v7 的目标范围。"
+
+### 模式 5：沉默的缺口（Silent Gap）
+
+**信号**：
+- 设计文档明确要求某样东西必须存在
+- 但代码中没有任何对应物，也没有任何 TODO、注释、或占位符
+- 这是一个"被遗忘的意图"
+
+**例子**：
+```text
+v8 合同: "ValidityEnvelope 是 MechanismProgram 的必备字段"
+代码: MechanismClass 有 thresholds/contextConstraints，但没有 ValidityEnvelope 结构
+→ 漂移：v8 的意图在代码中完全不可见
+```
+
+**测试 agent 的回应**：
+> "v8 的设计文档要求每个 `MechanismProgram` 必须附带 `ValidityEnvelope`，但我在代码中没有找到这个结构的任何痕迹。这不是一个部分实现的问题，而是一个完全缺失的意图。
+> 如果 v8 目前还不是开发重点，我建议至少在 `mechanism-class-contract.md` 中加入一个显式的 'v8 前瞻' 章节，把这个意图落盘，防止它被彻底遗忘。"
+
+---
+
+## 5. 审计工作流
+
+### 5.1 单次意图一致性审计的流程
+
+```text
+Step 1: 选择审计焦点
+  → 通常是一个 recent commit range 或一个 specific contract
+
+Step 2: 读取意图文档
+  → design_history 中的相关版本
+  → current/ 中的相关合同
+  → roadmap 中的 Phase 定位
+
+Step 3: 读取过程文档
+  → commit messages in range
+  → code frontmatter (implements)
+  → inline TODOs / HACKs / proxies
+  → existing contract-vs-impl audit findings
+
+Step 4: 构建意图-实现矩阵
+  ┌─────────────────┬─────────────────┬─────────────────┬──────────────┐
+  │ 意图来源        │ 意图声明        │ 实现状态        │ 漂移评估     │
+  ├─────────────────┼─────────────────┼─────────────────┼──────────────┤
+  │ v7 §10 条件 1   │ Episode timeline│ event log ✅    │ 部分漂移     │
+  │                 │                 │ snapshot ❌     │              │
+  ├─────────────────┼─────────────────┼─────────────────┼──────────────┤
+  │ mechanism-class │ replay 能力     │ phases 字段 ✅  │ 语义漂移     │
+  │ contract        │                 │ 但无实际 replay │              │
+  │                 │                 │ 引擎 ❌         │              │
+  └─────────────────┴─────────────────┴─────────────────┴──────────────┘
+
+Step 5: 生成对话式发现（Drift Findings）
+  → 对每个漂移，不直接报 bug，而是生成一个"问题 + 建议"对
+
+Step 6: 输出审计报告
+  → 结构化 markdown，包含：
+    - 审计范围
+    - 意图-实现矩阵
+    - 对话式发现列表
+    - 建议的下一步行动（按优先级排序）
+```
+
+### 5.2 与代码编写 agent 的交互协议
+
+测试 agent 的输出必须遵循以下格式：
+
+```markdown
+## 发现 #{n}: [漂移模式] 标题
+
+**意图来源**: `docs/current/xxx-contract.md` §Y / `design_history/vZ_xxx.md` §W
+**过程文档**: commit `abc1234` "..." / `src/core/xxx.ts` frontmatter
+**漂移描述**: （客观描述事实，不带情绪）
+**问题**: 
+1. ...
+2. ...
+**建议**: 
+1. ...
+2. ...
+**严重度**: info / minor / major / blocker（从项目意图完整性的角度评估）
+```
+
+**禁止的输出方式**：
+- ❌ "这里有个 bug"
+- ❌ "代码错了"
+- ❌ "文档写错了"
+
+**推荐的输出方式**：
+- ✅ "设计意图 X 要求 Y，但当前实现 Z 似乎是一个已知妥协。是否需要在合同中显式记录这个妥协？"
+- ✅ "commit 声称对齐了 A，但 B 仍然使用过渡态前缀。这是否说明对齐是分阶段的？如果是，建议补充分阶段计划。"
+
+---
+
+## 6. 自动化辅助：intent-alignment-audit.mjs
+
+为了降低人工审计的认知负担，项目维护一个自动化脚本 `scripts/intent-alignment-audit.mjs`，它负责：
+
+1. **扫描意图文档**：提取所有合同中的 "硬约束"、"不变量"、"TODO"、"必须" 等关键句
+2. **扫描过程文档**：
+   - 解析所有 `.mjs` / `.ts` 文件头部的 `// ---` frontmatter
+   - 提取所有 git commit message
+   - 提取代码中的 `TODO` / `HACK` / `proxy:` / `过渡态` 注释
+3. **构建映射**：
+   - 哪些合同被哪些代码文件 `implements`
+   - 哪些 commit 声称 "对齐"了哪些合同
+   - 哪些合同中的关键字段在代码中有/无对应
+4. **生成初稿报告**：输出一个带有 "漂移信号" 的 markdown，供测试 agent 进一步审阅和添加对话式发现
+
+**注意**：自动化脚本只能做"信号检测"，不能做"意图理解"。最终的对话式发现必须由测试 agent（人或 AI）基于上下文判断生成。
+
+---
+
+## 7. 当前项目的首次意图一致性审计
+
+### 7.1 审计范围
+
+- **时间范围**：最近 20 个 commit（`ff82b76` 到 `fee1d33`）
+- **焦点合同**：`v7-world-model-contract.md`、`mechanism-class-contract.md`、`metrics-contract.md`
+- **焦点代码**：`causal-learner/mcp-server/src/core/pipeline.ts`、`mechanism-instance.ts`、`mechanism-class.ts`
+
+### 7.2 意图-实现矩阵（示例）
+
+| 意图来源 | 意图声明 | 实现状态 | 漂移模式 | 评估 |
+|---------|---------|---------|---------|------|
+| v7 §10 条件 1 | Episode 具备完整 timeline | event log ✅, snapshot/transition ❌ | 模式 4：过度实现 event，缺口 snapshot | major |
+| v7 §10 条件 6 | AcceptedReconstruction 显式落盘 | ✅ 已实现 | 无漂移 | - |
+| v7 §10 条件 7 | OntologyDelta 必备输出 | ✅ 已实现（含 kind=none） | 无漂移 | - |
+| mechanism-class-contract §2 | MechanismClass 是可回放动力学模板 | phases 字段 ✅, 但无真实 replay 引擎 | 模式 1：宣称 vs 实际未完成 | major |
+| mechanism-class-contract §5 | replayError 计算 | formula 存在但依赖 episode timeline | 模式 2：高级意图 vs 低级妥协 | minor |
+| metrics-contract §2 | `regulations_confirmed` 来源 | 合同中写 `get_stats`，`eval.mjs` 实际用 `get_dual_stats` | 模式 3：合同间张力，代码已偷偷修正 | blocker |
+| v8 design | ValidityEnvelope | 代码中完全不存在 | 模式 5：沉默的缺口 | info |
+| v9 design | PerspectiveModel | 代码中完全不存在 | 模式 5：沉默的缺口 | info |
+
+### 7.3 对话式发现（精选）
+
+#### 发现 #1: Episode timeline 的"不平衡实现"
+
+**意图来源**: `v7-world-model-contract.md` §10 条件 1 / `episode-event-contract.md`
+**过程文档**: commit `f1649b1` "缺口二：Episode 轻量 timeline 持久化（EpisodeEventStore）"
+**漂移描述**: `EpisodeEventStore` 实现了完整的 event log（含 seq、kind、ref_id、payload），但 `StateSnapshot` 和 `Transition` 仍然是 `interface` 占位符，没有任何持久化存储。
+**问题**: 
+1. 如果 timeline 只有事件而没有状态快照，它是否能完整支持 v7 的"世界采样"意图？
+2. `EpisodeEvent` 的 payload 是否可以/应该被用来推断 `StateSnapshot`？
+**建议**: 
+1. 如果 StateSnapshot 的实现被刻意推迟，建议在 `v7-world-model-contract.md` §10 中把条件 1 拆分为 "event log ✅" 和 "snapshot/transition ⏳"，明确标注推迟原因。
+2. 或者，将 `StateSnapshotStore` 和 `TransitionStore` 提升为下一个 sprint 的优先项。
+**严重度**: major
+
+#### 发现 #2: "对齐" commit 中的过渡态残留
+
+**意图来源**: `mechanism-class-contract.md` §7 / `mechanism-instance-contract.md`
+**过程文档**: commits `7ac7777` "对齐新版 mechanism-instance 合约"、`8162bc4` "pipeline.recordFix() 产出 MechanismInstance"
+**漂移描述**: 多个 commit 声称 "对齐" 或 "产出" MechanismInstance，但 `mechanism_class_ref` 仍然使用 `proxy:hyp_xxx` 和 `proxy:episode_xxx` 前缀。合同要求这是 D3 过渡态，不应长期存在。
+**问题**: 
+1. proxy 前缀是否已经被接受为一种长期存在的桥接模式？
+2. 如果不是，从 proxy 到真实 `MC_*` ID 的迁移路径是什么？
+**建议**: 
+1. 在 `mechanism-instance-contract.md` 中新增一个 "过渡态退役计划" 章节，明确 proxy 前缀预计在哪个版本/哪个条件下被移除。
+2. 在 `pipeline.ts` 中 `proxy:` 生成的位置添加 TODO 注释，引用该退役计划。
+**严重度**: minor（因为它是已知过渡态，但缺乏退役承诺）
+
+#### 发现 #3: metrics 合同的"僵尸声明"
+
+**意图来源**: `metrics-contract.md` §2 字段表
+**过程文档**: `eval.mjs` 的字段映射代码（`buildMetrics` 函数）已将 `regulations_confirmed` 映射到 `dualStats.regulationsByStatus.confirmed`
+**漂移描述**: `metrics-contract.md` 声称 `regulations_confirmed` 来自 `get_stats`，但代码（`eval.mjs`）已经正确地从 `get_dual_stats` 采集。这意味着代码编写者已经意识到了合同错误并做了隐式修正，但没有更新合同本身。
+**问题**: 
+1. 如果未来的代码编写者或新加入的 agent 只读 `metrics-contract.md`，他们会错误实现采集逻辑吗？
+2. `contract-vs-impl-audit.md` 已经把这个问题标记为 B1 blocker，为什么合同没有被同步修正？
+**建议**: 
+1. 立即修正 `metrics-contract.md` §2 的"采集方式"列，把所有 `get_stats` 来源的错误字段更正为真实来源。
+2. 建立规则：当 `contract-vs-impl-audit.md` 发现一个 blocker 且代码已经做了修正时，必须在同一个 commit 或紧随其后的 commit 中修正合同。
+**严重度**: blocker
+
+#### 发现 #4: v8/v9 意图的"完全沉默"
+
+**意图来源**: `design_history/v8_generative_ontology.md`、`design_history/v9_ontology_federation.md`
+**过程文档**: 代码中没有任何 `ValidityEnvelope`、`PerspectiveModel`、`TranslationFunctor`、`OntologyModel` 的痕迹。没有任何 TODO 注释提及这些对象。
+**漂移描述**: v8 和 v9 的设计文档已经被正式落盘到 `design_history/`，但它们在代码层完全没有占位符或前瞻注释。这意味着这些意图有被遗忘的风险。
+**问题**: 
+1. v8/v9 目前是否被视为纯粹的"未来愿景"，而不是需要逐步渗透的架构方向？
+2. 如果是，为什么它们被写成了正式版本文档而不是 `future-ideas/`？
+**建议**: 
+1. 在相关的 current contracts（如 `v7-world-model-contract.md`、`mechanism-class-contract.md`）中增加 "v8/v9 前瞻" 附录，说明哪些字段/结构是为 v8/v9 预留的。
+2. 或者，在 `causal-learner/mcp-server/src/core/` 中创建占位符类型文件（如 `v8-placeholder.ts`），只 export interface 而不实现逻辑，作为意图的锚点。
+**严重度**: info（当前不影响功能，但影响长期架构一致性）
+
+---
+
+## 8. 从审计到改善：建议的下一步行动
+
+### 行动 1（本周）：修正 metrics-contract.md
+**原因**: 这是唯一一个 "代码已经修正但合同仍然错误" 的场景，会导致未来实现者被误导。
+**执行者**: 任意代码编写 agent
+**验证者**: 意图一致性审计 agent（运行 `scripts/intent-alignment-audit.mjs` 验证修正）
+
+### 行动 2（下周）：为 proxy 前缀建立退役计划
+**原因**: 消除 "宣称对齐但实际使用过渡态" 的模式 1 漂移。
+**执行者**: 负责 mechanism-instance 的编写 agent
+**验证者**: 意图一致性审计 agent（检查合同中是否新增了退役章节，代码中是否新增了 TODO）
+
+### 行动 3（下下周）：决定是否将 v8/v9 意图引入代码占位符
+**原因**: 防止高级设计意图被遗忘。
+**执行者**: 架构师 agent + 意图一致性审计 agent 共同决策
+**验证者**: 30 天后复查，检查代码中是否出现了至少一个 v8/v9 的占位符或 TODO
+
+---
+
+## 9. 最终判断
+
+意图一致性审计不是对代码编写 agent 的审判，而是一种**结构化对话**。
+
+它的价值不在于找出多少错误，而在于：
+1. **让设计意图保持可见**（防止意图被代码细节淹没）
+2. **让妥协变得显式**（防止临时方案变成永久方案）
+3. **让编写者的自我理解接受校准**（防止 commit message 的修辞与现实脱节）
+
+当一个测试 agent 能够说出：
+> "我理解了你的意图，也理解了你认为自己实现了什么，但这里有一个微妙的漂移——不是 bug，而是方向上的不一致。"
+
+它才真正成为了代码编写者的对话者与改善者。

--- a/docs/current/intent-alignment-report-template.md
+++ b/docs/current/intent-alignment-report-template.md
@@ -1,0 +1,385 @@
+---
+kind: contract
+status: draft
+phase: 1
+schema_version: 1
+describes: "意图一致性审计报告输出模板规范"
+---
+
+# 意图一致性审计报告模板合同
+
+> 本文档定义 `scripts/intent-alignment-audit.mjs` 及其衍生审计报告的**输出结构规范**。
+> 目标：让测试 agent 的输出从"信息堆砌"升级为"结构化对话"，使代码编写 agent 能在 3 分钟内定位关键矛盾、在 10 分钟内决定下一步行动。
+> 上游依赖：[intent-alignment-audit-contract.md](./intent-alignment-audit-contract.md)
+
+---
+
+## 1. 报告总体结构（七段式）
+
+每份意图一致性审计报告必须包含以下七个章节，顺序不可颠倒，缺失章节视为格式不完整。
+
+```
+# 意图一致性审计报告
+
+## 0. 执行摘要（Executive Summary）
+## 1. 审计范围声明（Scope）
+## 2. 意图-实现矩阵（Intent-Implementation Matrix）
+## 3. 矛盾与建议详表（Contradictions & Recommendations） ← 核心章节
+## 4. 对话式发现（Narrative Findings）
+## 5. 过程文档信号清单（Process Signals）
+## 6. 下一步行动建议（Action Items）
+```
+
+**长度建议**：
+- 整体报告：500–3000 行 markdown（取决于审计范围）
+- 核心章节（§3）应占全文 30%–50% 的篇幅
+- 任何单一条目不得超过 40 行，超过必须拆分
+
+---
+
+## 2. 各章节内容规范
+
+### §0 执行摘要（Executive Summary）
+
+**目的**：让忙碌的代码编写者在 30 秒内了解"这次审计最值得关注的 3 件事"。
+
+**必填内容**：
+- 生成时间
+- 扫描范围（commit 数、合同数、代码文件数）
+- 5 个关键指标的表格
+
+**表格格式**（严格固定）：
+
+```markdown
+| 维度 | 结果 | 趋势 |
+|------|------|------|
+| 合同总数 | N | vs 上次 ±n |
+| 宣称对齐但未完成 (模式 1) | N | vs 上次 ±n |
+| 完全沉默的缺口 (模式 5) | N | vs 上次 ±n |
+| 合同-代码直接矛盾 | N | vs 上次 ±n |
+| 最高优先级行动 | 一句话 | - |
+```
+
+**约束**：
+- 不允许在此章节展开细节
+- 趋势列必须与前一次审计报告做对比（首次审计可写 "baseline"）
+
+---
+
+### §1 审计范围声明（Scope）
+
+**目的**：让读者明白"这次审计看了什么、没看什么"。
+
+**必填内容**：
+- 时间范围（commit hash 起止）
+- 焦点合同列表（若有 `--focus-contract` 参数）
+- 扫描的目录范围
+- **显式排除项**（如 "未审计外部依赖"、"未审计可视化层"）
+
+**格式示例**：
+
+```markdown
+- **Commit 范围**: `abc1234` .. `def5678`（共 20 个 commit）
+- **焦点合同**: `v7-world-model-contract.md`、`metrics-contract.md`
+- **扫描代码**: `causal-learner/mcp-server/src/core/*.ts`、`scripts/*.mjs`
+- **显式排除**: `external/`、`visualization/`、`.github/workflows/`（仅在 CI 审计中扫描）
+```
+
+---
+
+### §2 意图-实现矩阵（Intent-Implementation Matrix）
+
+**目的**：提供一张可快速检索的"全景地图"。
+
+**表格格式**（严格固定 6 列）：
+
+```markdown
+| 意图来源 | 合同状态 | 代码声称实现 | 对齐 commit | 实现状态 | 漂移信号 |
+|----------|----------|--------------|-------------|----------|----------|
+```
+
+**列定义**：
+1. **意图来源**：合同文件名（只显示 basename，完整路径在链接中）
+2. **合同状态**：`current` / `draft` / `mixed` / `reference`
+3. **代码声称实现**：通过 `implements` frontmatter 关联的代码文件列表，或 `(无)`
+4. **对齐 commit**：commit subject 中包含 "对齐/收束/修正" 等关键词的 commit 数量
+5. **实现状态**：
+   - `claimed_implemented` — 代码声称实现且无过渡态信号
+   - `partial_with_proxy` — 声称实现但仍有 proxy 过渡态
+   - `partial_with_todo` — 声称实现但仍有 TODO/HACK
+   - `no_code_claim` — 无任何代码文件认领
+   - `unknown` — 无法判断
+6. **漂移信号**：
+   - `-` — 无漂移
+   - `mode1_claimed_but_incomplete` — 宣称对齐但未完成
+   - `mode2_intent_vs_compromise` — 高级意图 vs 低级妥协
+   - `mode3_contract_tension` — 合同间张力，代码已偷偷修正
+   - `mode4_over_implemented` — 过度实现某部分，忽略关键缺口
+   - `mode5_silent_gap` — 完全沉默的缺口
+
+**约束**：
+- 每行必须能在不换行的情况下完整显示
+- 若"代码声称实现"列文件数 > 2，只显示前 2 个并加注 "+N more"
+
+---
+
+### §3 矛盾与建议详表（Contradictions & Recommendations）
+
+**目的**：这是报告的核心章节。不是罗列发现，而是**结构化地呈现矛盾，并给出改善项目的具体建议**。
+
+**格式**：采用编号条目 `C1`, `C2`, `C3`... 每个条目必须包含以下 5 个固定字段：
+
+```markdown
+### C{n}: 标题（不超过 20 字）
+
+- **矛盾点**：
+  一句话概括冲突的本质。禁止只说"不一致"，必须说出"什么 vs 什么"不一致。
+  
+- **意图侧**：
+  合同/设计文档宣称的目标。必须引用具体的文件和章节。
+  
+- **实现侧**：
+  代码/过程文档实际呈现的状态。必须引用具体的文件和行号（若有）。
+  
+- **改善建议**：
+  1. 第一条建议（最紧急或最有价值的行动）
+  2. 第二条建议（若适用）
+  3. 可选的第三条建议
+  
+- **优先级**：P0 / P1 / P2 / P3
+```
+
+**优先级定义**：
+- **P0**：会误导未来的实现者，或导致数据/逻辑错误。建议 24 小时内处理。
+- **P1**：意图-实现链断裂，影响可审计性和可传承性。建议本周内处理。
+- **P2**：已知妥协或过渡态，但需要更清晰的文档化。建议两周内处理。
+- **P3**：前瞻性、预防性的建议。可排入 backlog。
+
+**条目筛选规则**：
+- 最多展示 8 条 C 级条目，超过时按优先级排序，同优先级按影响范围排序
+- 不得将多个无关的矛盾合并为一条
+- 不得在没有具体文件/行号引用的情况下写 "代码中存在" 这类模糊表述
+
+**改善建议的质量标准**：
+- ❌ 差建议："修正代码"、"更新文档"
+- ✅ 好建议："在 `metrics-contract.md` §2 的'采集方式'列增加 `get_dual_stats` 来源注释，并删除对 `get_stats` 的引用"、"给 `pipeline.ts` 头部添加 `// implements: docs/current/pipeline-contract.md` frontmatter"
+
+---
+
+### §4 对话式发现（Narrative Findings）
+
+**目的**：为需要更多上下文的读者提供"为什么这个矛盾重要"的叙事。
+
+**格式**：采用 `### 发现 #{n}: 漂移模式名称` 作为小标题。
+
+每个发现必须包含：
+- **意图来源**：具体文件
+- **代码声称实现**：具体文件
+- **对齐 commit**：若有
+- **信号证据**：具体的代码信号（如 `proxy:` 前缀在某行）
+- **问题**：以 `> **问题**:` 引用的blockquote，包含 1–3 个结构化问题
+
+**约束**：
+- 此章节的内容必须是 §3 矛盾详表的**补充说明**，不能包含 §3 中未提及的新矛盾
+- 若某条矛盾在 §3 中已经写得很清楚，§4 只需写 `> 详见 **C{n}: xxx**`。
+
+---
+
+### §5 过程文档信号清单（Process Signals）
+
+**目的**：展示代码中的"自我理解痕迹"——TODO、proxy、alignment-claim 等。
+
+**格式**：按信号类型分组，每组一个三级标题。
+
+```markdown
+### todo (N 处)
+- `file:line` 内容摘要
+...
+
+### proxy (N 处)
+- `file:line` 内容摘要
+...
+```
+
+**约束**：
+- 每组最多显示 10 条，超过时写 "... 还有 N 处"
+- 内容摘要不得超过 80 字符
+- 必须包含精确的 `file:line` 引用
+
+---
+
+### §6 下一步行动建议（Action Items）
+
+**目的**：将前面的所有发现压缩为可执行的待办清单。
+
+**格式**：编号列表，每条必须包含动宾结构、负责者（agent 类型）、验证标准。
+
+```markdown
+1. **[P0] 修正 metrics-contract.md 的字段来源声明**
+   - 负责者：文档维护 agent
+   - 行动：将 §2 中 `regulations_confirmed` 的采集方式从 `get_stats` 改为 `get_dual_stats`
+   - 验证：运行 `node scripts/contract-audit.mjs` 不再报 B1 blocker
+```
+
+**约束**：
+- 最多列出 6 条行动建议
+- 必须按优先级排序
+- 每条行动必须有明确的"验证标准"（如何判断这条行动已完成）
+
+---
+
+## 3. 输出产物的元数据要求
+
+每次审计必须同时产出两份文件：
+
+1. **`artifacts/intent-alignment-audit-latest.md`**
+   - 人类可读报告（遵循本模板）
+   - 用于代码编写 agent 快速审阅和决策
+
+2. **`artifacts/intent-alignment-audit-latest.json`**
+   - 机器可读结构化数据
+   - 必须包含以下顶层字段：
+     ```json
+     {
+       "timestamp": "ISO 8601",
+       "commits_scanned": 20,
+       "contracts_scanned": 35,
+       "designs_scanned": 12,
+       "code_files_with_frontmatter": 5,
+       "code_signals": 21,
+       "matrix": [...],
+       "contradictions": [
+         {
+           "id": "C1",
+           "title": "...",
+           "priority": "P1",
+           "intent_source": "...",
+           "implementation_source": "..."
+         }
+       ],
+       "action_items": [...]
+     }
+     ```
+
+---
+
+## 4. 与前身格式的对比
+
+| 维度 | 旧格式（contract-vs-impl-audit.md 式） | 新模板（本合同） |
+|------|----------------------------------------|------------------|
+| 核心结构 | 表格清单（偏差 #1-#N） | 七段式报告 |
+| 矛盾呈现 | 简短一句话 | 意图侧 vs 实现侧的完整对照 |
+| 建议质量 | "改契约"、"标记为 0%" | 精确到文件、行号、时间窗的行动 |
+| 可读性 | 适合审计者自己看 | 适合编写 agent 快速决策 |
+| 自动化 | 手工撰写 | 脚本自动生成 80%，人工润色 20% |
+
+---
+
+## 5. 附录：快速检查清单（Checklist）
+
+发布一份意图一致性审计报告前，确认：
+
+- [ ] §0 执行摘要包含 5 个固定指标
+- [ ] §1 审计范围明确列出了"显式排除项"
+- [ ] §2 意图-实现矩阵的 6 列标题完全匹配规范
+- [ ] §3 至少包含 1 条、不超过 8 条 C 级矛盾条目
+- [ ] §3 的每条矛盾都有 "矛盾点 / 意图侧 / 实现侧 / 改善建议 / 优先级" 五个字段
+- [ ] §4 没有引入 §3 中未提及的新矛盾
+- [ ] §5 的信号清单按类型分组，每组最多 10 条
+- [ ] §6 的行动建议不超过 6 条，且都有验证标准
+- [ ] JSON 产物包含 `contradictions` 和 `action_items` 数组
+- [ ] 全文没有 "bug"、"错误"、"不对" 等审判性词汇
+
+---
+
+## 6. 模板示例（完整片段）
+
+```markdown
+# 意图一致性审计报告
+
+生成时间: 2026-04-14T03:57:05.479Z
+扫描 commit 数: 30
+扫描代码文件数: 已扫描
+
+## 0. 执行摘要
+
+| 维度 | 结果 | 趋势 |
+|------|------|------|
+| 合同总数 | 35 | baseline |
+| 宣称对齐但未完成 (模式 1) | 2 | baseline |
+| 完全沉默的缺口 (模式 5) | 32 | baseline |
+| 合同-代码直接矛盾 | 4 | baseline |
+| 最高优先级行动 | 修正 metrics-contract.md 的僵尸声明 | - |
+
+---
+
+## 1. 审计范围声明
+
+- **Commit 范围**: `fee1d33` .. `ff82b76`（共 30 个 commit）
+- **焦点合同**: `metrics-contract.md`、`mechanism-class-contract.md`
+- **扫描代码**: `causal-learner/mcp-server/src/core/*.ts`、`scripts/*.mjs`
+- **显式排除**: `external/`、`visualization/`、`.github/workflows/`
+
+---
+
+## 2. 意图-实现矩阵
+
+| 意图来源 | 合同状态 | 代码声称实现 | 对齐 commit | 实现状态 | 漂移信号 |
+|----------|----------|--------------|-------------|----------|----------|
+| artifact-contract.md | draft | eval.mjs, export-v7-artifacts.mjs | - | partial_with_proxy | mode1_claimed_but_incomplete |
+| metrics-contract.md | current | (无) | - | no_code_claim | mode5_silent_gap |
+
+---
+
+## 3. 矛盾与建议详表
+
+### C1: metrics 合同采集来源与 eval.mjs 行为矛盾
+
+- **矛盾点**：
+  合同声称 `regulations_confirmed` 来自 `get_stats`，但 `eval.mjs` 已正确将其映射到 `get_dual_stats().regulationsByStatus.confirmed`。
+  
+- **意图侧**：
+  `metrics-contract.md` §2 是 metrics 字段的"唯一真相源"。
+  
+- **实现侧**：
+  `scripts/eval.mjs:175-228` 的 `buildMetrics()` 函数实际从 `statsAfter.dualStats.regulationsByStatus.confirmed` 取值。
+  
+- **改善建议**：
+  1. 立即修正 `metrics-contract.md` §2 的"采集方式"列，按真实工具拆分来源。
+  2. 建立规则：当 `contract-vs-impl-audit.md` 标记 blocker 且代码已修正时，24 小时内同步修正合同。
+  
+- **优先级**：P0
+
+---
+
+## 4. 对话式发现
+
+### 发现 #1: metrics 合同的僵尸声明（模式 3）
+
+> 详见 **C1: metrics 合同采集来源与 eval.mjs 行为矛盾**。
+
+---
+
+## 5. 过程文档信号清单
+
+### todo (14 处)
+- `mechanism-instance.ts:19` | 'path_projection' // 过渡态...
+...
+
+---
+
+## 6. 下一步行动建议
+
+1. **[P0] 修正 metrics-contract.md**
+   - 负责者：文档维护 agent
+   - 行动：修正 §2 字段来源声明
+   - 验证：`contract-audit.mjs` 不再报 B1 blocker
+```
+
+---
+
+## 7. 版本历史
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| 1 | 2026-04-14 | 初版。定义七段式报告结构、C 级矛盾条目格式、输出产物规范。 |

--- a/docs/current/reporting-workflow-contract.md
+++ b/docs/current/reporting-workflow-contract.md
@@ -1,0 +1,154 @@
+---
+kind: contract
+status: current
+phase: 0
+schema_version: 1
+describes: "任务回报文件命名、路径与模板规范"
+---
+
+# Reporting Workflow 合同：任务回报不再依赖人工复制
+
+## §1 目标
+
+后续实现与测试结果回流，**不再依赖用户把 Claude 的聊天内容复制给我**。
+
+统一改成：
+
+```text
+编号任务
+  → brief
+  → 固定 report 文件
+  → 我读取 report 文件更新规划
+```
+
+一句话：
+
+> 人不是 message bus，仓库里的固定报告文件才是。
+
+## §2 固定目录
+
+所有任务回报统一写入：
+
+```text
+.omx/reports/
+```
+
+## §3 命名规则
+
+每个任务一个固定 report 文件：
+
+```text
+.omx/reports/P02-program-revision-proposal-governance.md
+.omx/reports/P03-supportlink-deep-audit.md
+.omx/reports/P04-mechanismclass-promotion-gate.md
+```
+
+命名格式：
+
+```text
+P<编号>-<slug>.md
+```
+
+要求：
+
+1. 与编号队列中的 `Pxx` 一一对应
+2. slug 稳定，不随一次对话措辞变化
+3. 同一任务持续迭代时，覆盖同一个 report 文件，而不是新建多个名字
+
+## §4 report 模板
+
+每个 report 文件必须使用以下结构：
+
+```md
+# P02 Report
+
+## Task
+- P02 ProgramRevisionProposal governance
+
+## Changed Files
+- file A
+- file B
+
+## Verification
+- npm run build: pass
+- test-foo.mjs: 10/10
+
+## Risks
+- risk A
+- risk B
+
+## Decision
+- done | partial | blocked
+
+## Next Handoff
+- optional next step
+```
+```
+
+## §5 字段要求
+
+### 5.1 `Task`
+
+必须明确：
+
+- 任务编号
+- 任务名称
+
+### 5.2 `Changed Files`
+
+必须列出：
+
+- 真实修改过的文件
+
+### 5.3 `Verification`
+
+必须列出：
+
+- 实际跑过的验证命令或测试
+- 结果
+
+### 5.4 `Risks`
+
+必须写：
+
+- 仍未解决的风险
+- 或明确写 `- none`
+
+### 5.5 `Decision`
+
+只允许：
+
+- `done`
+- `partial`
+- `blocked`
+
+## §6 与 brief 的关系
+
+以后每个 Claude brief 都应包含：
+
+1. 固定 report 文件路径
+2. 要求把结果写入该路径
+3. 不要只在聊天中回报
+
+## §7 与规划更新的关系
+
+我后续更新编号队列时，只把以下信息当成一级真相来源：
+
+1. 代码和测试的本地复核
+2. `.omx/reports/*.md`
+3. commit 历史
+
+不再把“用户复制来的二手摘要”当默认真相来源。
+
+## §8 不变量
+
+1. 每个 active 任务都应有固定 report 路径
+2. 同一任务不得散落多个 report 文件
+3. 无 report 文件的回报不算正式收口
+4. 若 `Decision=done`，必须有 `Verification`
+
+## §9 版本历史
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| 1 | 2026-04-14 | 初版。把任务结果回流从人工复制改成固定 report 文件流程 |

--- a/scripts/intent-alignment-audit.mjs
+++ b/scripts/intent-alignment-audit.mjs
@@ -1,0 +1,641 @@
+#!/usr/bin/env node
+// ---
+// kind: code
+// implements: docs/current/intent-alignment-audit-contract.md
+// also related: docs/current/contract-audit-contract.md
+// ---
+/**
+ * 意图一致性审计脚本 —— 测试 agent 与代码编写 agent 的对话基础设施
+ *
+ * 职责：
+ *   1. 扫描意图文档（design_history + current contracts）提取关键约束
+ *   2. 扫描过程文档（commit log + code frontmatter + TODO/HACK/proxy）
+ *   3. 构建意图-实现矩阵初稿
+ *   4. 输出结构化 markdown 报告，供测试 agent 进一步审阅
+ *
+ * 用法：
+ *   node scripts/intent-alignment-audit.mjs [--commits 20] [--focus-contract v7-world-model-contract]
+ */
+
+import { readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const execFileP = promisify(execFile);
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(__filename), '..');
+const DOCS_CURRENT = path.join(ROOT, 'docs', 'current');
+const DOCS_DESIGN = path.join(ROOT, 'docs', 'design_history');
+const SRC_DIR = path.join(ROOT, 'causal-learner', 'mcp-server', 'src');
+const SCRIPTS_DIR = path.join(ROOT, 'scripts');
+const ARTIFACTS_DIR = path.join(ROOT, 'artifacts');
+const OUT_MD = path.join(ARTIFACTS_DIR, 'intent-alignment-audit-latest.md');
+const OUT_JSON = path.join(ARTIFACTS_DIR, 'intent-alignment-audit-latest.json');
+
+// ── CLI 参数解析 ────────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const out = { commits: 20, focusContract: null };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--commits' && argv[i + 1]) { out.commits = Number(argv[++i]) || 20; }
+    if (a === '--focus-contract' && argv[i + 1]) { out.focusContract = argv[++i]; }
+  }
+  return out;
+}
+const args = parseArgs(process.argv);
+
+// ── 通用工具 ────────────────────────────────────────────────────────────────
+function stripBom(s) { return s.charCodeAt(0) === 0xFEFF ? s.slice(1) : s; }
+
+function unquote(s) {
+  if (typeof s !== 'string') return s;
+  const m = s.match(/^"([^"]*)"$/) || s.match(/^'([^']*)'$/);
+  return m ? m[1] : s;
+}
+
+function parseMarkdownFrontmatter(text) {
+  text = stripBom(text);
+  const lines = text.split(/\r?\n/);
+  if (lines[0] !== '---') return { fm: {}, body: text };
+  let end = -1;
+  for (let i = 1; i < lines.length; i++) if (lines[i] === '---') { end = i; break; }
+  if (end < 0) return { fm: {}, body: text };
+  const fm = {};
+  for (let i = 1; i < end; i++) {
+    const m = lines[i].match(/^([a-zA-Z_$][\w$-]*):\s*(.*)$/);
+    if (m) fm[m[1]] = unquote(m[2].trim());
+  }
+  return { fm, body: lines.slice(end + 1).join('\n') };
+}
+
+function parseJsFrontmatter(text) {
+  text = stripBom(text);
+  const lines = text.split(/\r?\n/);
+  let start = -1, end = -1;
+  for (let i = 0; i < lines.length && i < 50; i++) {
+    const l = lines[i].trim();
+    if (l === '' || l.startsWith('#!')) continue;
+    if (l === '// ---') { start = i; break; }
+    if (!l.startsWith('//')) return { fm: {}, body: text };
+  }
+  if (start < 0) return { fm: {}, body: text };
+  for (let i = start + 1; i < lines.length && i < 80; i++) {
+    if (lines[i].trim() === '// ---') { end = i; break; }
+  }
+  if (end < 0) return { fm: {}, body: text };
+  const fm = {};
+  for (let i = start + 1; i < end; i++) {
+    const m = lines[i].match(/^\s*\/\/\s*([a-zA-Z_$][\w$-]*):\s*(.*)$/);
+    if (m) fm[m[1]] = unquote(m[2].trim());
+  }
+  return { fm, body: lines.slice(end + 1).join('\n') };
+}
+
+async function listFilesRec(dir, exts) {
+  const out = [];
+  let entries;
+  try { entries = await readdir(dir, { withFileTypes: true }); }
+  catch { return out; }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...await listFilesRec(full, exts));
+    else if (e.isFile() && exts.some(x => e.name.endsWith(x))) out.push(full);
+  }
+  return out;
+}
+
+// ── 1. 扫描意图文档 ──────────────────────────────────────────────────────────
+async function scanIntentDocs() {
+  const contracts = [];
+  const designs = [];
+
+  // current contracts
+  try {
+    for (const f of await readdir(DOCS_CURRENT)) {
+      if (!f.endsWith('.md')) continue;
+      const text = await readFile(path.join(DOCS_CURRENT, f), 'utf8');
+      const { fm, body } = parseMarkdownFrontmatter(text);
+      contracts.push({ file: f, fm, body });
+    }
+  } catch {}
+
+  // design history
+  try {
+    for (const f of await readdir(DOCS_DESIGN)) {
+      if (!f.endsWith('.md')) continue;
+      const text = await readFile(path.join(DOCS_DESIGN, f), 'utf8');
+      const { fm, body } = parseMarkdownFrontmatter(text);
+      designs.push({ file: f, fm, body });
+    }
+  } catch {}
+
+  return { contracts, designs };
+}
+
+function contractAcknowledgesTransition(body) {
+  const lower = body.toLowerCase();
+  const signals = ['proxy', '过渡态', '占位', 'placeholder', '退役', 'retire', 'transition', 'temporary', '近似'];
+  return signals.some(s => lower.includes(s));
+}
+
+function extractHardConstraints(body) {
+  const constraints = [];
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const l = lines[i];
+    // 匹配 "硬约束"、"不变量"、"铁律"、"必须"、"禁止"、"不得" 等信号
+    if (/^#{1,3}\s*([^#]*约束|[^#]*不变量|[^#]*铁律|[^#]*法律)/i.test(l)) {
+      constraints.push({ type: 'section', title: l.replace(/^#+\s*/, ''), line: i + 1 });
+    }
+    if (/^\s*[-*]\s*(必须|禁止|不得|只能|只可|铁律)/.test(l) || /^\s*\|\s*[^|]*\|\s*(必须|禁止|不得)/.test(l)) {
+      constraints.push({ type: 'item', text: l.trim(), line: i + 1 });
+    }
+    if (/^\s*```text\s*$/.test(l) && i + 1 < lines.length && /(必须|禁止|不得|铁律)/.test(lines[i + 1])) {
+      const block = [];
+      let j = i + 1;
+      while (j < lines.length && !/^\s*```\s*$/.test(lines[j])) {
+        block.push(lines[j]);
+        j++;
+      }
+      constraints.push({ type: 'block', text: block.join('\n'), line: i + 1 });
+    }
+  }
+  return constraints;
+}
+
+function extractTypeScriptInterfaces(body) {
+  const interfaces = [];
+  const re = /interface\s+(\w+)\s*\{([^}]*)\}/gs;
+  for (const m of body.matchAll(re)) {
+    const name = m[1];
+    const content = m[2];
+    const fields = [];
+    for (const fm of content.matchAll(/(\w+)\??\s*:/g)) {
+      fields.push(fm[1]);
+    }
+    interfaces.push({ name, fields: fields.slice(0, 20) }); // 限制字段数避免爆炸
+  }
+  return interfaces;
+}
+
+// ── 2. 扫描过程文档 ──────────────────────────────────────────────────────────
+async function scanProcessDocs(commitCount) {
+  // git log
+  let commits = [];
+  try {
+    const { stdout } = await execFileP('git', ['log', `--max-count=${commitCount}`, '--format=%H %s'], { cwd: ROOT });
+    commits = stdout.split(/\r?\n/).filter(Boolean).map(line => {
+      const space = line.indexOf(' ');
+      return { hash: line.slice(0, space), subject: line.slice(space + 1) };
+    });
+  } catch {}
+
+  // code frontmatter
+  const codeFiles = [];
+  const srcFiles = await listFilesRec(SRC_DIR, ['.ts', '.mjs', '.js']);
+  const scriptFiles = await listFilesRec(SCRIPTS_DIR, ['.mjs', '.js']);
+  for (const abs of [...srcFiles, ...scriptFiles]) {
+    const text = await readFile(abs, 'utf8');
+    const { fm } = parseJsFrontmatter(text);
+    if (Object.keys(fm).length > 0) {
+      codeFiles.push({
+        file: path.relative(ROOT, abs).replace(/\\/g, '/'),
+        fm,
+      });
+    }
+  }
+
+  return { commits, codeFiles };
+}
+
+// ── 3. 扫描代码信号 ──────────────────────────────────────────────────────────
+async function scanCodeSignals() {
+  const signals = [];
+  const srcFiles = await listFilesRec(SRC_DIR, ['.ts']);
+  let scriptFiles = await listFilesRec(SCRIPTS_DIR, ['.mjs', '.js']);
+  // 排除意图一致性审计脚本自身，避免自引用噪音
+  scriptFiles = scriptFiles.filter(f => !f.endsWith('intent-alignment-audit.mjs'));
+
+  for (const abs of [...srcFiles, ...scriptFiles]) {
+    const text = await readFile(abs, 'utf8');
+    const lines = text.split(/\r?\n/);
+    const rel = path.relative(ROOT, abs).replace(/\\/g, '/');
+
+    for (let i = 0; i < lines.length; i++) {
+      const l = lines[i];
+      // proxy:* 前缀
+      if (/proxy:/i.test(l)) {
+        signals.push({ file: rel, line: i + 1, kind: 'proxy', text: l.trim() });
+      }
+      // TODO / HACK / FIXME / 过渡态 / 占位
+      if (/(TODO|HACK|FIXME|过渡态|占位|待建|placeholder)/i.test(l)) {
+        signals.push({ file: rel, line: i + 1, kind: 'todo', text: l.trim() });
+      }
+      // 对齐 / 收束 / 修正 commit 的内联注释
+      if (/(对齐|收束|修正|对齐上游)/.test(l) && /contract|合同|上游/.test(l)) {
+        signals.push({ file: rel, line: i + 1, kind: 'alignment-claim', text: l.trim() });
+      }
+      // v8/v9 前瞻信号
+      if (/(ValidityEnvelope|PerspectiveModel|TranslationFunctor|OntologyModel|CounterfactualScenario)/.test(l)) {
+        signals.push({ file: rel, line: i + 1, kind: 'future-intent', text: l.trim() });
+      }
+    }
+  }
+
+  return signals;
+}
+
+// ── 4. 构建意图-实现矩阵 ─────────────────────────────────────────────────────
+function buildAlignmentMatrix({ contracts, designs, commits, codeFiles, codeSignals }) {
+  const matrix = [];
+
+  // 4.1 从合同中提取关键意图项
+  const intentItems = [];
+  for (const c of contracts) {
+    if (c.fm.status !== 'current' && c.fm.status !== 'draft') continue;
+    const constraints = extractHardConstraints(c.body);
+    const interfaces = extractTypeScriptInterfaces(c.body);
+    intentItems.push({
+      source: `docs/current/${c.file}`,
+      kind: 'contract',
+      status: c.fm.status,
+      describes: c.fm.describes || '',
+      constraints,
+      interfaces,
+      acknowledgesTransition: contractAcknowledgesTransition(c.body),
+    });
+  }
+  for (const d of designs) {
+    // 提取版本号中的关键口号和最终判断
+    const slogans = [];
+    const lines = d.body.split(/\r?\n/);
+    for (let i = 0; i < lines.length; i++) {
+      if (/^#{1,3}\s*(系统口号|最终判断|核心主张)/.test(lines[i])) {
+        slogans.push({ section: lines[i].replace(/^#+\s*/, ''), line: i + 1 });
+      }
+    }
+    intentItems.push({
+      source: `docs/design_history/${d.file}`,
+      kind: 'design',
+      slogans,
+    });
+  }
+
+  // 4.2 构建 implements 映射
+  const implementsMap = new Map(); // contract file -> code files[]
+  for (const cf of codeFiles) {
+    const imp = cf.fm.implements;
+    if (!imp) continue;
+    const items = String(imp).split(',').map(s => s.trim()).filter(Boolean);
+    for (const item of items) {
+      // 标准化 key：支持 docs/current/xxx.md 和 current/xxx.md 都映射到 xxx.md
+      let key = item;
+      if (key.startsWith('docs/current/')) key = key.slice('docs/current/'.length);
+      else if (key.startsWith('current/')) key = key.slice('current/'.length);
+      if (!implementsMap.has(key)) implementsMap.set(key, []);
+      implementsMap.get(key).push(cf.file);
+    }
+  }
+
+  // 4.3 构建 commit 对齐声明映射
+  const alignmentCommits = commits.filter(c =>
+    /对齐|收束|修正|对齐上游/.test(c.subject)
+  );
+
+  // 4.4 生成矩阵行
+  for (const intent of intentItems) {
+    if (intent.kind === 'contract') {
+      const contractKey = intent.source.replace('docs/current/', '');
+      const implementedBy = implementsMap.get(contractKey) || [];
+      const alignedCommits = alignmentCommits.filter(c =>
+        c.subject.toLowerCase().includes(contractKey.toLowerCase().replace('.md', ''))
+      );
+
+      // 检查接口字段是否在声称实现的代码文件中可见（精确匹配到文件本身）
+      const hasProxy = codeSignals.some(s =>
+        s.kind === 'proxy' && implementedBy.some(f => s.file === f || s.file.startsWith(f.replace(/\.\w+$/, '')))
+      );
+      const hasTodo = codeSignals.some(s =>
+        s.kind === 'todo' && implementedBy.some(f => s.file === f || s.file.startsWith(f.replace(/\.\w+$/, '')))
+      );
+
+      const acknowledgesTransition = intent.acknowledgesTransition ?? false;
+
+      let implementationStatus = 'unknown';
+      if (implementedBy.length === 0) implementationStatus = 'no_code_claim';
+      else if (hasProxy && !acknowledgesTransition) implementationStatus = 'partial_with_proxy';
+      else if (hasTodo && !acknowledgesTransition) implementationStatus = 'partial_with_todo';
+      else if ((hasProxy || hasTodo) && acknowledgesTransition) implementationStatus = 'claimed_with_known_transition';
+      else implementationStatus = 'claimed_implemented';
+
+      let driftSignal = 'none';
+      if (implementationStatus === 'partial_with_proxy' || implementationStatus === 'partial_with_todo') {
+        driftSignal = 'mode1_claimed_but_incomplete';
+      } else if (implementationStatus === 'no_code_claim') {
+        driftSignal = 'mode5_silent_gap';
+      }
+
+      matrix.push({
+        intentSource: intent.source,
+        intentDesc: intent.describes,
+        contractStatus: intent.status,
+        implementedBy,
+        alignedCommits: alignedCommits.map(c => `${c.hash.slice(0, 7)} ${c.subject}`),
+        implementationStatus,
+        driftSignal,
+      });
+    }
+  }
+
+  // 4.5 检查 design_history 中的 v8/v9 意图是否有代码信号
+  const futureSignals = codeSignals.filter(s => s.kind === 'future-intent');
+  const hasV8V9InCode = futureSignals.length > 0;
+
+  return { matrix, futureSignals, hasV8V9InCode, intentItems };
+}
+
+// ── 5. 生成报告 ──────────────────────────────────────────────────────────────
+function generateReport({ matrix, futureSignals, hasV8V9InCode, commits, codeSignals, contracts }) {
+  const now = new Date().toISOString();
+
+  // 严重度计数
+  const driftCounts = { mode1: 0, mode2: 0, mode3: 0, mode4: 0, mode5: 0 };
+  for (const row of matrix) {
+    if (row.driftSignal === 'mode1_claimed_but_incomplete') driftCounts.mode1++;
+    if (row.driftSignal === 'mode5_silent_gap') driftCounts.mode5++;
+  }
+  // 额外检查 mode3: metrics-contract 僵尸声明
+  const metricsRow = matrix.find(r => r.intentSource.includes('metrics-contract.md'));
+  const hasMetricsDrift = metricsRow && metricsRow.implementedBy.some(f => f.includes('eval.mjs'));
+
+  const lines = [
+    '# 意图一致性审计报告',
+    '',
+    `生成时间: ${now}`,
+    `扫描 commit 数: ${commits.length}`,
+    `扫描代码文件数: ${codeSignals.length > 0 ? '已扫描' : '未扫描'}`,
+    '',
+    '## 执行摘要',
+    '',
+    '| 维度 | 结果 |',
+    '|------|------|',
+    `| 合同总数 | ${matrix.length} |`,
+    `| 宣称对齐但未完成 (模式 1) | ${driftCounts.mode1} |`,
+    `| 完全沉默的缺口 (模式 5) | ${driftCounts.mode5} |`,
+    `| metrics 僵尸声明 (模式 3) | ${hasMetricsDrift ? '1 (eval.mjs 已修正但合同未更新)' : '0'} |`,
+    `| v8/v9 未来意图代码信号 | ${hasV8V9InCode ? `${futureSignals.length} 处` : '0 (完全沉默)'} |`,
+    '',
+    '---',
+    '',
+    '## 1. 意图-实现矩阵',
+    '',
+    '| 意图来源 | 合同状态 | 代码声称实现 | 对齐 commit | 实现状态 | 漂移信号 |',
+    '|----------|----------|--------------|-------------|----------|----------|',
+  ];
+
+  for (const row of matrix) {
+    const impl = row.implementedBy.length > 0 ? row.implementedBy.join('<br>') : '(无)';
+    const commits = row.alignedCommits.length > 0 ? `${row.alignedCommits.length} 个` : '-';
+    const status = row.implementationStatus;
+    const drift = row.driftSignal === 'none' ? '-' : row.driftSignal;
+    lines.push(`| ${path.basename(row.intentSource)} | ${row.contractStatus || '-'} | ${impl} | ${commits} | ${status} | ${drift} |`);
+  }
+
+  lines.push('', '---', '', '## 2. 矛盾与建议详表', '');
+
+  // C1: artifact-contract 的稳定产物意图 vs 过渡态代码
+  const artifactRow = matrix.find(r => r.intentSource.includes('artifact-contract.md'));
+  if (artifactRow && artifactRow.driftSignal === 'mode1_claimed_but_incomplete') {
+    lines.push(
+      '### C1: artifact-contract 要求"稳定产物"，但实现脚本仍使用过渡态',
+      '',
+      '- **矛盾点**：合同定义了 `artifacts/<run_id>/` 的落盘规范，并要求 v7 对象导出使用稳定的目录结构和 ID 格式；但 `export-v7-artifacts.mjs:172` 生成 `proxy:demo_` 前缀的 `mechanism_class_ref`，且 `capture-baseline.mjs:40` 仍有 TODO。',
+      '- **意图侧**：`artifact-contract.md` §5 期望 v7 产物是结构化的、可审计的实例文件。',
+      '- **实现侧**：代码通过 `implements` 声称实现了该合同，但产物中仍包含演示性质的过渡数据。',
+      '- **改善建议**：',
+      '  1. 在 `artifact-contract.md` 顶部新增 "Phase 1 限制" 附录，明确记录："v7 对象导出的 `mechanism_class_ref` 目前使用 `proxy:*` 前缀作为过渡态，真实 `MC_*` ID 的绑定将在 MechanismClass 完全实现后替换。"',
+      '  2. 给 `export-v7-artifacts.mjs:172` 添加 inline 注释，引用上述附录。',
+      '- **优先级**: P1',
+      ''
+    );
+  }
+
+  // C2: metrics 合同僵尸声明
+  if (hasMetricsDrift) {
+    lines.push(
+      '### C2: metrics-contract 的采集来源声明与 eval.mjs 实际行为矛盾',
+      '',
+      '- **矛盾点**：合同声称 `regulations_confirmed` / `events_open` 来自 `get_stats`，但 `eval.mjs` 的 `buildMetrics()` 已正确将其映射到 `get_dual_stats().regulationsByStatus.confirmed`。',
+      '- **意图侧**：`metrics-contract.md` §2 是 metrics 字段的"唯一真相源"。',
+      '- **实现侧**：代码编写者已经意识到了合同错误并做了隐式修正，但没有更新合同本身。',
+      '- **改善建议**：',
+      '  1. 立即修正 `metrics-contract.md` §2 的"采集方式"列，按真实工具（`get_stats` / `get_dual_stats` / `get_longterm_stats` / `graph_stats`）拆分字段来源。',
+      '  2. 建立一条团队规则：当 `contract-vs-impl-audit.md` 标记一个 blocker，且代码已做修正时，必须在 24 小时内同步修正合同，防止合同变成"僵尸声明"。',
+      '- **优先级**: P0',
+      ''
+    );
+  }
+
+  // C3: 大量合同无代码认领
+  const silentCurrentContracts = matrix.filter(r => r.driftSignal === 'mode5_silent_gap' && r.contractStatus === 'current');
+  if (silentCurrentContracts.length > 0) {
+    lines.push(
+      `### C3: ${silentCurrentContracts.length} 份 current 合同无任何代码文件认领 implements`,
+      '',
+      `- **矛盾点**：这些合同被标记为 \`status: current\`（已冻结），但没有代码文件通过 \`implements\` 声明与它们建立关联。`,
+      '- **意图侧**：current 合同应该代表已经稳定、正在被执行的意图。',
+      '- **实现侧**：代码层缺少对 current 合同的显式认领，导致意图-实现的追溯链断裂。',
+      '- **改善建议**：',
+      `  1. 对 ${silentCurrentContracts.length} 份 silent current 合同进行分类：有些是纯元文档（如 \`file-taxonomy-contract.md\`），不需要被代码实现，建议将其 \`status\` 改为 \`reference\`；`,
+      '  2. 有些合同（如 `ref-algebra-contract.md`、`pipeline-contract.md`、`compile-promotion-contract.md`）的核心逻辑确实存在于代码中，建议给对应的 `.ts` 文件补一个 `// implements:` frontmatter，建立显式链接。',
+      '- **优先级**: P1',
+      ''
+    );
+  }
+
+  // C4: v8/v9 完全沉默
+  if (!hasV8V9InCode) {
+    lines.push(
+      '### C4: v8/v9 设计意图在代码层零占位符',
+      '',
+      '- **矛盾点**：`design_history/` 中已经正式落盘了 v8（生成式本体）和 v9（本体联邦），但代码中找不到任何 `ValidityEnvelope`、`PerspectiveModel`、`TranslationFunctor`、`OntologyModel` 的占位符或 TODO。',
+      '- **意图侧**：v8/v9 被视为正式版本演进方向，不是临时笔记。',
+      '- **实现侧**：系统完全没有任何代码信号来锚定这些高级意图，存在被遗忘的风险。',
+      '- **改善建议**：',
+      '  1. 在 `mechanism-class-contract.md` 末尾增加 "v8 前瞻" 附录，说明 `phases/thresholds/contextConstraints` 字段未来会升级为 `ValidityEnvelope`。',
+      '  2. 在 `v7-world-model-contract.md` 中增加 "v9 前瞻" 附录，说明 `Episode.perspectiveId` 和 `OntologyModel` 是 v9 联邦层的预留字段。',
+      '  3. （可选）创建 `causal-learner/mcp-server/src/core/v8-placeholder.ts`，只 export 空 interface，不实现任何逻辑，作为意图的代码锚点。',
+      '- **优先级**: P2',
+      ''
+    );
+  }
+
+  // C5: mechanism-class 可回放 vs 无真实 replay 引擎
+  const mcRow = matrix.find(r => r.intentSource.includes('mechanism-class-contract.md'));
+  const hasProxyInCore = codeSignals.some(s => s.kind === 'proxy' && s.file.includes('core/'));
+  if (hasProxyInCore) {
+    lines.push(
+      '### C5: mechanism-class 合同承诺"可回放"，但核心代码仍依赖 proxy 过渡态',
+      '',
+      '- **矛盾点**：`mechanism-class-contract.md` §2 定义 `MechanismClass` 是可回放的动力学模板，但 `pipeline.ts:558-561` 生成 `proxy:hyp_xxx` / `proxy:episode_xxx` 作为 `mechanism_class_ref`。',
+      '- **意图侧**：合同要求 MechanismClass 具备 `phases` 和 `replayError` 计算，能够按 phases 回放 Episode timeline。',
+      '- **实现侧**：由于真实的 `MechanismClass` 晋升路径尚未打通（多 Episode 门控、replay 一致性检查），`recordFix()` 仍然用 proxy 前缀来桥接。',
+      '- **改善建议**：',
+      '  1. 在 `mechanism-class-contract.md` 中新增 "proxy 前缀退役计划" 章节，明确三个条件：(a) MechanismInstanceStore 中 accepted 状态 ≥2 个独立 episode；(b) replayError < 0.3；(c) 通过 counterexample 检查。',
+      '  2. 当条件满足时，触发一个自动化提醒（或 CI check），提示可以开始移除 proxy 前缀。',
+      '- **优先级**: P1',
+      ''
+    );
+  }
+
+  lines.push('---', '', '## 3. 精选发现（对话式）', '');
+
+  // 发现 1: 模式 1 漂移
+  const mode1Rows = matrix.filter(r => r.driftSignal === 'mode1_claimed_but_incomplete');
+  if (mode1Rows.length > 0) {
+    lines.push(
+      '### 发现 #1: 宣称对齐但未完成（模式 1）',
+      ''
+    );
+    for (const row of mode1Rows.slice(0, 3)) {
+      const proxySigs = codeSignals.filter(s => s.kind === 'proxy' && row.implementedBy.some(f => s.file === f || s.file.startsWith(f.replace(/\.\w+$/, ''))));
+      const todoSigs = codeSignals.filter(s => s.kind === 'todo' && row.implementedBy.some(f => s.file === f || s.file.startsWith(f.replace(/\.\w+$/, ''))));
+      lines.push(
+        `**意图来源**: \`${row.intentSource}\``,
+        `**代码声称实现**: ${row.implementedBy.join(', ')}`,
+        `**对齐 commit**: ${row.alignedCommits.slice(0, 2).join('; ') || '无'}`,
+      );
+      if (proxySigs.length > 0) {
+        lines.push(`**过渡态信号**: \`${proxySigs[0].file}:${proxySigs[0].line}\` 含有 \`proxy:\` 前缀`);
+      }
+      if (todoSigs.length > 0) {
+        lines.push(`**待建信号**: \`${todoSigs[0].file}:${todoSigs[0].line}\` 含有 TODO/HACK`);
+      }
+      lines.push(
+        '> **问题**: commit 或代码 frontmatter 声称实现了这份合同，但代码中仍存在过渡态（proxy）或待建标记（TODO）。这是否意味着对齐是分阶段的？如果是，建议在合同中明确记录分阶段计划。',
+        ''
+      );
+    }
+  }
+
+  // 发现 2: 模式 5 漂移
+  const mode5Rows = matrix.filter(r => r.driftSignal === 'mode5_silent_gap');
+  if (mode5Rows.length > 0) {
+    lines.push(
+      '### 发现 #2: 沉默的缺口（模式 5）',
+      ''
+    );
+    for (const row of mode5Rows.slice(0, 3)) {
+      lines.push(
+        `**意图来源**: \`${row.intentSource}\``,
+        `**合同状态**: ${row.contractStatus}`,
+        `**代码声称实现**: (无)`,
+        '> **问题**: 这份合同有明确的 current/draft 状态，但没有任何代码文件通过 `implements` 声称实现它。如果它确实不重要，建议将其降级为 reference；如果它应该被实现，建议至少创建一个占位符代码文件并添加 `implements` 声明。',
+        ''
+      );
+    }
+  }
+
+  // 发现 3: metrics 僵尸声明（已在矛盾表中详述，此处简要引用）
+  if (hasMetricsDrift) {
+    lines.push(
+      '### 发现 #3: metrics 合同的僵尸声明（模式 3）',
+      '',
+      '> 详见 **C2: metrics-contract 的采集来源声明与 eval.mjs 实际行为矛盾**。',
+      ''
+    );
+  }
+
+  // 发现 4: v8/v9 完全沉默（已在矛盾表中详述，此处简要引用）
+  if (!hasV8V9InCode) {
+    lines.push(
+      '### 发现 #4: v8/v9 意图在代码层完全沉默（模式 5）',
+      '',
+      '> 详见 **C4: v8/v9 设计意图在代码层零占位符**。',
+      ''
+    );
+  }
+
+  lines.push(
+    '---',
+    '',
+    '## 3. 代码信号清单',
+    ''
+  );
+
+  const byKind = new Map();
+  for (const s of codeSignals) {
+    if (!byKind.has(s.kind)) byKind.set(s.kind, []);
+    byKind.get(s.kind).push(s);
+  }
+  for (const [kind, items] of byKind) {
+    lines.push(`### ${kind} (${items.length} 处)`);
+    for (const it of items.slice(0, 10)) {
+      lines.push(`- \`${it.file}:${it.line}\` ${it.text.slice(0, 80)}${it.text.length > 80 ? '...' : ''}`);
+    }
+    if (items.length > 10) lines.push(`- ... 还有 ${items.length - 10} 处`);
+    lines.push('');
+  }
+
+  lines.push(
+    '---',
+    '',
+    '## 4. 下一步行动建议',
+    '',
+    '1. **修正 metrics-contract.md**：同步 `eval.mjs` 中已经正确的字段来源。',
+    '2. **为 proxy 前缀建立退役计划**：消除 mechanism-instance 层的模式 1 漂移。',
+    '3. **评估 v8/v9 占位符**：决定是否在当前代码中加入前瞻类型声明。',
+    '4. **检查沉默的合同**：确认 `mode5_silent_gap` 列表中的合同是否真的不需要代码实现。',
+    ''
+  );
+
+  return lines.join('\n');
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  console.log(`[intent-alignment-audit] 开始审计... commits=${args.commits}`);
+
+  const { contracts, designs } = await scanIntentDocs();
+  console.log(`  意图文档: ${contracts.length} 份合同, ${designs.length} 份设计历史`);
+
+  const { commits, codeFiles } = await scanProcessDocs(args.commits);
+  console.log(`  过程文档: ${commits.length} 个 commit, ${codeFiles.length} 份代码 frontmatter`);
+
+  const codeSignals = await scanCodeSignals();
+  console.log(`  代码信号: ${codeSignals.length} 处`);
+
+  const { matrix, futureSignals, hasV8V9InCode } = buildAlignmentMatrix({
+    contracts, designs, commits, codeFiles, codeSignals,
+  });
+  console.log(`  意图-实现矩阵: ${matrix.length} 行`);
+
+  const report = generateReport({ matrix, futureSignals, hasV8V9InCode, commits, codeSignals, contracts });
+
+  await mkdir(ARTIFACTS_DIR, { recursive: true });
+  await writeFile(OUT_MD, report, 'utf8');
+
+  const payload = {
+    timestamp: new Date().toISOString(),
+    commits_scanned: commits.length,
+    contracts_scanned: contracts.length,
+    designs_scanned: designs.length,
+    code_files_with_frontmatter: codeFiles.length,
+    code_signals: codeSignals.length,
+    matrix,
+    future_signals_count: futureSignals.length,
+    has_v8v9_in_code: hasV8V9InCode,
+  };
+  await writeFile(OUT_JSON, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+
+  console.log(`\n报告已生成:`);
+  console.log(`  markdown: ${path.relative(ROOT, OUT_MD).replace(/\\/g, '/')}`);
+  console.log(`  json:     ${path.relative(ROOT, OUT_JSON).replace(/\\/g, '/')}`);
+}
+
+main().catch(err => {
+  console.error('[intent-alignment-audit] 失败:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #8

## Summary
- intent-alignment 审计脚本
- 审计输出 artifacts
- 合约文档 + 报告模板

🤖 Generated with [Claude Code](https://claude.com/claude-code)