### PR TITLE
feat: v8 运行时函数 — executePhasedProgram + inferCounterfactual + computeInformationGain

### DIFF
--- a/causal-learner/mcp-server/src/core/counterfactual-scenario.ts
+++ b/causal-learner/mcp-server/src/core/counterfactual-scenario.ts
@@ -7,6 +7,11 @@
  */
 
 import crypto from 'crypto';
+import {
+  MechanismProgram,
+  ExecutionContext,
+  executePhasedProgram,
+} from './mechanism-program.js';
 
 // =============================================================================
 // 类型定义
@@ -70,6 +75,103 @@ export interface CreateCounterfactualScenarioInput {
   divergencePoints?: string[];
   createdBy?: string;
   status?: CounterfactualScenario['status'];
+}
+
+// =============================================================================
+// 反事实推演引擎
+// =============================================================================
+
+/**
+ * 基于 MechanismProgram 推演反事实场景。
+ *
+ * 将 modifiedAssumptions 中的 set/remove 操作转为 stateOverrides，
+ * 将 intervention 类型的 assumption 映射到 stopBeforePhase，
+ * 调用 executePhasedProgram 获得预测轨迹，打包为 CounterfactualScenario。
+ */
+export function inferCounterfactual(
+  program: MechanismProgram,
+  baselineContext: ExecutionContext,
+  assumptions: CounterfactualAssumption[],
+  baseEpisodeId: string,
+  baseReconstructionId: string,
+): CounterfactualScenario {
+  // 构建状态覆盖
+  const stateOverrides: Record<string, unknown> = {};
+  for (const a of assumptions) {
+    if (a.modification === 'set' && a.toValue !== undefined) {
+      stateOverrides[a.targetRef] = a.toValue;
+    } else if (a.modification === 'remove') {
+      stateOverrides[a.targetRef] = undefined;
+    }
+  }
+
+  // 找第一个映射到干预点的 assumption
+  const interventionAssumption = assumptions.find(
+    a => program.interventionPoints.includes(a.targetRef),
+  );
+  const programIntervention = interventionAssumption
+    ? {
+        stopBeforePhase: interventionAssumption.targetRef,
+        stateOverrides,
+        reason: assumptions.map(a => a.rationale ?? a.targetRef).join('; '),
+      }
+    : stateOverrides && Object.keys(stateOverrides).length > 0
+    ? { stopBeforePhase: '', stateOverrides, reason: 'state_override_only' }
+    : undefined;
+
+  const trajectory = executePhasedProgram(program, baselineContext, programIntervention);
+
+  // 构建 PredictedStep 列表
+  const predictedTrajectory: PredictedStep[] = [];
+
+  // 步骤 0：初始状态快照
+  predictedTrajectory.push({
+    step: 0,
+    kind: 'initial_condition',
+    content: Object.entries(trajectory.contextSnapshot.stateVars)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(', ') || '(empty context)',
+    source: 'episode_anchored',
+  });
+
+  // 每个 phase 结果
+  for (let i = 0; i < trajectory.phaseResults.length; i++) {
+    const r = trajectory.phaseResults[i];
+    predictedTrajectory.push({
+      step: i + 1,
+      kind: r.executed ? 'latent_phase' : 'intervention',
+      content: r.executed
+        ? `${r.phaseName}: [${r.stateChangesApplied.join(', ') || 'no state changes'}] obs=[${r.observationsEmitted.join(', ')}]`
+        : `${r.phaseName}: halted — ${r.haltReason}`,
+      source: 'program_simulated',
+    });
+  }
+
+  // 最终结局
+  predictedTrajectory.push({
+    step: predictedTrajectory.length,
+    kind: 'outcome',
+    content: trajectory.finalOutcome,
+    source: 'program_simulated',
+  });
+
+  const divergencePoints = assumptions
+    .filter(a => a.fromValue !== undefined && a.fromValue !== a.toValue)
+    .map(a => a.targetRef);
+
+  return createCounterfactualScenario({
+    baseEpisodeId,
+    baseReconstructionId,
+    modifiedAssumptions: assumptions,
+    mechanismProgramRefs: [program.id],
+    predictedTrajectory,
+    predictedObservationSignals: trajectory.phaseResults
+      .filter(r => r.executed)
+      .flatMap(r => r.observationsEmitted),
+    predictedOutcome: trajectory.finalOutcome,
+    divergencePoints,
+    status: 'current',
+  });
 }
 
 export function createCounterfactualScenario(

--- a/causal-learner/mcp-server/src/core/experiment-design.ts
+++ b/causal-learner/mcp-server/src/core/experiment-design.ts
@@ -60,6 +60,86 @@ export interface CreateExperimentDesignInput {
   status?: ExperimentDesign['status'];
 }
 
+// =============================================================================
+// 信息增益计算引擎
+// =============================================================================
+
+/**
+ * 假设预测器：给定一个候选动作，每个假设会预测哪些观测信号。
+ */
+export interface HypothesisPredictor {
+  /** MechanismClass ID 或假设标识符 */
+  hypothesisId: string;
+  /** 该假设在此动作下预测会出现的观测信号 keys */
+  predictedSignals: string[];
+}
+
+/**
+ * 计算某个候选动作在一组假设下的信息增益。
+ *
+ * 原理：统计「执行该动作后，能区分的假设对数 / 总假设对数」。
+ * 两个假设"可区分"= 它们预测的信号集合不完全相同。
+ *
+ * 返回值在 [0, 1]：0 = 完全无法区分，1 = 每对假设均可区分。
+ */
+export function computeInformationGain(
+  hypotheses: HypothesisPredictor[],
+): number {
+  if (hypotheses.length <= 1) return 0;
+
+  let discriminatingPairs = 0;
+  let totalPairs = 0;
+
+  for (let i = 0; i < hypotheses.length; i++) {
+    for (let j = i + 1; j < hypotheses.length; j++) {
+      totalPairs++;
+      const sigsI = new Set(hypotheses[i].predictedSignals);
+      const sigsJ = new Set(hypotheses[j].predictedSignals);
+      // 两个信号集合不完全相同 → 可区分
+      const isDistinct =
+        hypotheses[i].predictedSignals.some(s => !sigsJ.has(s)) ||
+        hypotheses[j].predictedSignals.some(s => !sigsI.has(s));
+      if (isDistinct) discriminatingPairs++;
+    }
+  }
+
+  return totalPairs > 0 ? discriminatingPairs / totalPairs : 0;
+}
+
+/**
+ * 从候选动作集合中选出信息增益最大的实验。
+ *
+ * @param actionPredictors - 每个候选动作对应一组假设预测器
+ * @returns 最优动作、信息增益值、所有动作的区分力 map
+ */
+export function selectOptimalExperiment(
+  actionPredictors: Record<string, HypothesisPredictor[]>,
+): {
+  bestAction: string;
+  informationGain: number;
+  discriminatingPower: Record<string, number>;
+} {
+  const candidates = Object.keys(actionPredictors);
+  if (candidates.length === 0) {
+    return { bestAction: '', informationGain: 0, discriminatingPower: {} };
+  }
+
+  const discriminatingPower: Record<string, number> = {};
+  let bestAction = candidates[0];
+  let bestGain = -1;
+
+  for (const action of candidates) {
+    const gain = computeInformationGain(actionPredictors[action] ?? []);
+    discriminatingPower[action] = gain;
+    if (gain > bestGain) {
+      bestGain = gain;
+      bestAction = action;
+    }
+  }
+
+  return { bestAction, informationGain: Math.max(0, bestGain), discriminatingPower };
+}
+
 export function createExperimentDesign(
   input: CreateExperimentDesignInput
 ): ExperimentDesign {

--- a/causal-learner/mcp-server/src/core/mechanism-program.ts
+++ b/causal-learner/mcp-server/src/core/mechanism-program.ts
@@ -121,6 +121,125 @@ export function createMechanismProgram(input: CreateMechanismProgramInput): Mech
 }
 
 // =============================================================================
+// 运行时执行（Phase 推演引擎）
+// =============================================================================
+
+/** 执行时的世界状态快照 */
+export interface ExecutionContext {
+  /** 世界状态变量 key → value */
+  stateVars: Record<string, unknown>;
+}
+
+/** 干预：在指定 phase 停止并覆盖部分状态变量 */
+export interface ProgramIntervention {
+  /** 在哪个 phase 名处停止（执行到该 phase 之前停止） */
+  stopBeforePhase: string;
+  /** 覆盖哪些状态变量 */
+  stateOverrides?: Record<string, unknown>;
+  /** 干预说明 */
+  reason: string;
+}
+
+/** 单个 phase 的执行结果 */
+export interface PhaseExecutionResult {
+  phaseName: string;
+  executed: boolean;
+  stateChangesApplied: string[];
+  observationsEmitted: string[];
+  haltReason?: string;
+}
+
+/** 完整的 phase 执行轨迹 */
+export interface PhasedTrajectory {
+  programId: string;
+  contextSnapshot: ExecutionContext;
+  phaseResults: PhaseExecutionResult[];
+  finalOutcome: string;
+  completedPhases: number;
+  totalPhases: number;
+  wasInterrupted: boolean;
+}
+
+/**
+ * 执行 MechanismProgram 的 phase 序列。
+ *
+ * - 无干预：顺序执行所有 phase，返回成功结局
+ * - 有干预：在 stopBeforePhase 处停止，返回 interrupted 结局
+ * - failsWhen：检测 stateVars 中满足失效条件的情况（格式 "key=value"）
+ */
+export function executePhasedProgram(
+  program: MechanismProgram,
+  context: ExecutionContext,
+  intervention?: ProgramIntervention,
+): PhasedTrajectory {
+  // 应用干预的初始状态覆盖
+  const activeContext: ExecutionContext = {
+    stateVars: { ...context.stateVars, ...(intervention?.stateOverrides ?? {}) },
+  };
+
+  const phaseResults: PhaseExecutionResult[] = [];
+  let wasInterrupted = false;
+  let finalOutcome = program.outcomes.find(o => /confirm|success|complete/i.test(o))
+    ?? program.outcomes[0]
+    ?? 'completed';
+
+  for (const phase of program.phases) {
+    // 干预点：在该 phase 之前停止
+    if (intervention && intervention.stopBeforePhase === phase.name) {
+      phaseResults.push({
+        phaseName: phase.name,
+        executed: false,
+        stateChangesApplied: [],
+        observationsEmitted: [],
+        haltReason: `intervention: ${intervention.reason}`,
+      });
+      wasInterrupted = true;
+      finalOutcome = `interrupted_before_${phase.name}`;
+      break;
+    }
+
+    // 检测 failsWhen 条件（格式 "key=value"）
+    const failCondition = program.failsWhen.find(cond => {
+      const eq = cond.indexOf('=');
+      if (eq < 0) return false;
+      const key = cond.slice(0, eq).trim();
+      const val = cond.slice(eq + 1).trim();
+      return String(activeContext.stateVars[key]) === val;
+    });
+
+    if (failCondition) {
+      phaseResults.push({
+        phaseName: phase.name,
+        executed: false,
+        stateChangesApplied: [],
+        observationsEmitted: [],
+        haltReason: `failsWhen: ${failCondition}`,
+      });
+      wasInterrupted = true;
+      finalOutcome = program.outcomes.find(o => /reject|fail/i.test(o)) ?? 'failed';
+      break;
+    }
+
+    phaseResults.push({
+      phaseName: phase.name,
+      executed: true,
+      stateChangesApplied: [...phase.expectedStateChanges],
+      observationsEmitted: [...phase.expectedObservations],
+    });
+  }
+
+  return {
+    programId: program.id,
+    contextSnapshot: activeContext,
+    phaseResults,
+    finalOutcome,
+    completedPhases: phaseResults.filter(r => r.executed).length,
+    totalPhases: program.phases.length,
+    wasInterrupted,
+  };
+}
+
+// =============================================================================
 // 默认 MechanismProgram（第一轮：所有 path_projection MechanismInstance 共享）
 // =============================================================================
 

--- a/causal-learner/mcp-server/src/tests/v8-runtime.test.ts
+++ b/causal-learner/mcp-server/src/tests/v8-runtime.test.ts
@@ -1,0 +1,238 @@
+/**
+ * v8 运行时函数测试
+ * 覆盖 executePhasedProgram、inferCounterfactual、computeInformationGain、selectOptimalExperiment
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createMechanismProgram,
+  executePhasedProgram,
+  type ExecutionContext,
+} from '../core/mechanism-program.js';
+import { inferCounterfactual } from '../core/counterfactual-scenario.js';
+import {
+  computeInformationGain,
+  selectOptimalExperiment,
+  type HypothesisPredictor,
+} from '../core/experiment-design.js';
+
+// =============================================================================
+// 测试用 MechanismProgram：BrewCoffee
+// =============================================================================
+
+function makeBrewCoffeeProgram() {
+  return createMechanismProgram({
+    mechanismClassRef: 'MC_brew_coffee',
+    name: 'BrewCoffee',
+    description: '咖啡机世界：heat → press → extract',
+    inputStateRefs: ['hasPower', 'waterLevel', 'beanLevel'],
+    phases: [
+      {
+        name: 'heat',
+        expectedStateChanges: ['temperature=high'],
+        expectedObservations: ['temperature'],
+      },
+      {
+        name: 'press',
+        expectedStateChanges: ['pressure=high'],
+        expectedObservations: ['pressure'],
+      },
+      {
+        name: 'extract',
+        expectedStateChanges: ['cup.fillLevel=full'],
+        expectedObservations: ['cup.fillLevel'],
+      },
+    ],
+    outcomes: ['coffee_brewed', 'brew_failed'],
+    interventionPoints: ['heat', 'press'],
+    failsWhen: ['hasPower=false'],
+  });
+}
+
+const baseContext: ExecutionContext = {
+  stateVars: { hasPower: true, waterLevel: 'full', beanLevel: 'full' },
+};
+
+// =============================================================================
+// executePhasedProgram 测试
+// =============================================================================
+
+describe('executePhasedProgram', () => {
+  it('正常路径：所有 phase 执行完毕', () => {
+    const program = makeBrewCoffeeProgram();
+    const result = executePhasedProgram(program, baseContext);
+
+    assert.equal(result.wasInterrupted, false);
+    assert.equal(result.completedPhases, 3);
+    assert.equal(result.totalPhases, 3);
+    assert.equal(result.finalOutcome, 'coffee_brewed');
+    assert.deepEqual(
+      result.phaseResults.map(r => r.phaseName),
+      ['heat', 'press', 'extract'],
+    );
+    assert.ok(result.phaseResults.every(r => r.executed));
+  });
+
+  it('干预路径：stopBeforePhase=press 时轨迹在 press 前中止', () => {
+    const program = makeBrewCoffeeProgram();
+    const result = executePhasedProgram(program, baseContext, {
+      stopBeforePhase: 'press',
+      reason: 'pump_disabled',
+    });
+
+    assert.equal(result.wasInterrupted, true);
+    assert.equal(result.completedPhases, 1); // 只有 heat 完成
+    assert.ok(result.finalOutcome.includes('interrupted'));
+    assert.equal(result.phaseResults[0].executed, true);  // heat 执行了
+    assert.equal(result.phaseResults[1].executed, false); // press 被拦截
+  });
+
+  it('failsWhen 路径：hasPower=false 时第一个 phase 中止', () => {
+    const program = makeBrewCoffeeProgram();
+    const noPowerCtx: ExecutionContext = {
+      stateVars: { hasPower: false, waterLevel: 'full', beanLevel: 'full' },
+    };
+    const result = executePhasedProgram(program, noPowerCtx);
+
+    assert.equal(result.wasInterrupted, true);
+    assert.equal(result.completedPhases, 0);
+    assert.ok(result.finalOutcome === 'brew_failed' || /fail/i.test(result.finalOutcome));
+  });
+
+  it('stateOverrides 被合并到执行上下文', () => {
+    const program = makeBrewCoffeeProgram();
+    const result = executePhasedProgram(program, baseContext, {
+      stopBeforePhase: 'extract',
+      stateOverrides: { waterLevel: 'empty' },
+      reason: 'water_drained',
+    });
+
+    assert.equal(result.contextSnapshot.stateVars['waterLevel'], 'empty');
+  });
+});
+
+// =============================================================================
+// inferCounterfactual 测试
+// =============================================================================
+
+describe('inferCounterfactual', () => {
+  it('hasPower=false 干预：轨迹停在 heat phase 之前', () => {
+    const program = makeBrewCoffeeProgram();
+    const cs = inferCounterfactual(
+      program,
+      baseContext,
+      [{ targetRef: 'hasPower', modification: 'set', fromValue: true, toValue: false, rationale: '电源关闭' }],
+      'ep_001',
+      'rec_001',
+    );
+
+    assert.equal(cs.status, 'current');
+    assert.ok(cs.predictedTrajectory.length >= 2);
+    // 结局应该是 failed
+    const outcomeStep = cs.predictedTrajectory.find(s => s.kind === 'outcome');
+    assert.ok(outcomeStep);
+    assert.ok(/fail/i.test(outcomeStep!.content));
+    assert.equal(cs.divergencePoints.includes('hasPower'), true);
+  });
+
+  it('干预点 press：轨迹在 press 前中断', () => {
+    const program = makeBrewCoffeeProgram();
+    const cs = inferCounterfactual(
+      program,
+      baseContext,
+      [{ targetRef: 'press', modification: 'set', fromValue: 'normal', toValue: 'disabled', rationale: '泵故障' }],
+      'ep_002',
+      'rec_002',
+    );
+
+    const outcomeStep = cs.predictedTrajectory.find(s => s.kind === 'outcome');
+    assert.ok(outcomeStep);
+    assert.ok(/interrupt/i.test(outcomeStep!.content));
+  });
+
+  it('predictedObservationSignals 只包含已执行 phase 的信号', () => {
+    const program = makeBrewCoffeeProgram();
+    // 正常执行：所有 phase 信号都应出现
+    const cs = inferCounterfactual(
+      program,
+      baseContext,
+      [{ targetRef: 'dummy', modification: 'set', fromValue: 0, toValue: 1 }],
+      'ep_003',
+      'rec_003',
+    );
+    // heat + press + extract 各自的 observation
+    assert.ok(cs.predictedObservationSignals.includes('temperature'));
+    assert.ok(cs.predictedObservationSignals.includes('pressure'));
+    assert.ok(cs.predictedObservationSignals.includes('cup.fillLevel'));
+  });
+});
+
+// =============================================================================
+// computeInformationGain 测试
+// =============================================================================
+
+describe('computeInformationGain', () => {
+  it('单一假设：增益为 0', () => {
+    const h: HypothesisPredictor[] = [{ hypothesisId: 'MC_A', predictedSignals: ['temperature'] }];
+    assert.equal(computeInformationGain(h), 0);
+  });
+
+  it('完全相同的预测：增益为 0', () => {
+    const h: HypothesisPredictor[] = [
+      { hypothesisId: 'MC_A', predictedSignals: ['temperature', 'pressure'] },
+      { hypothesisId: 'MC_B', predictedSignals: ['temperature', 'pressure'] },
+    ];
+    assert.equal(computeInformationGain(h), 0);
+  });
+
+  it('完全不同的预测：增益为 1', () => {
+    const h: HypothesisPredictor[] = [
+      { hypothesisId: 'MC_PumpFailure', predictedSignals: ['temperature'] },
+      { hypothesisId: 'MC_HeaterFailure', predictedSignals: ['pressure'] },
+    ];
+    assert.equal(computeInformationGain(h), 1);
+  });
+
+  it('部分区分：增益在 (0, 1)', () => {
+    const h: HypothesisPredictor[] = [
+      { hypothesisId: 'MC_A', predictedSignals: ['temperature', 'pressure'] },
+      { hypothesisId: 'MC_B', predictedSignals: ['temperature'] },
+      { hypothesisId: 'MC_C', predictedSignals: ['temperature', 'pressure'] },
+    ];
+    const gain = computeInformationGain(h);
+    assert.ok(gain > 0 && gain < 1, `expected 0 < gain < 1, got ${gain}`);
+  });
+});
+
+// =============================================================================
+// selectOptimalExperiment 测试
+// =============================================================================
+
+describe('selectOptimalExperiment', () => {
+  it('MC_PumpFailure vs MC_HeaterFailure：measure_pressure 区分力更高', () => {
+    const actionPredictors: Record<string, HypothesisPredictor[]> = {
+      measure_temperature: [
+        { hypothesisId: 'MC_PumpFailure', predictedSignals: ['temperature_low'] },
+        { hypothesisId: 'MC_HeaterFailure', predictedSignals: ['temperature_low'] },
+      ],
+      measure_pressure: [
+        { hypothesisId: 'MC_PumpFailure', predictedSignals: ['pressure_low'] },
+        { hypothesisId: 'MC_HeaterFailure', predictedSignals: ['pressure_normal'] },
+      ],
+    };
+
+    const result = selectOptimalExperiment(actionPredictors);
+    assert.equal(result.bestAction, 'measure_pressure');
+    assert.ok(result.informationGain > 0);
+    assert.equal(result.discriminatingPower['measure_temperature'], 0);
+    assert.equal(result.discriminatingPower['measure_pressure'], 1);
+  });
+
+  it('空候选集：返回空字符串', () => {
+    const result = selectOptimalExperiment({});
+    assert.equal(result.bestAction, '');
+    assert.equal(result.informationGain, 0);
+  });
+});


### PR DESCRIPTION
Closes #22
Closes #23
Closes #24

## Summary
- `executePhasedProgram` — 执行 MechanismProgram 的 phase 序列，支持干预和 failsWhen 条件
- `inferCounterfactual` — 基于 program + assumptions 推演反事实轨迹
- `computeInformationGain` — 计算候选动作对一组假设的区分力 [0,1]
- `selectOptimalExperiment` — 从候选集选出信息增益最大的实验
- 13 个新测试，38 pass, 0 fail

## Test plan
- [x] executePhasedProgram：正常路径、干预路径、failsWhen 路径
- [x] inferCounterfactual：hasPower=false、press 干预、信号过滤
- [x] computeInformationGain：边界值 0/1、部分区分
- [x] selectOptimalExperiment：MC_PumpFailure vs MC_HeaterFailure 区分

🤖 Generated with [Claude Code](https://claude.com/claude-code)