### PR TITLE
feat: v9 OntologyFederation — OntologyModel + TranslationFunctor + ConflictSet

### DIFF
--- a/causal-learner/mcp-server/src/core/conflict-set-store.ts
+++ b/causal-learner/mcp-server/src/core/conflict-set-store.ts
@@ -1,0 +1,93 @@
+/**
+ * ConflictSetStore — SQLite 持久化层
+ */
+
+import Database, { Database as DatabaseType } from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ConflictSet } from './conflict-set.js';
+
+interface ConflictSetRow {
+  id: string;
+  name: string;
+  translation_functor_id: string;
+  entry_count: number;
+  status: string;
+  created_at: string;
+  data: string;
+}
+
+function rowToConflictSet(row: ConflictSetRow): ConflictSet {
+  return JSON.parse(row.data) as ConflictSet;
+}
+
+export class ConflictSetStore {
+  private db: DatabaseType;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ':memory:') {
+      const dir = path.dirname(dbPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    }
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.initSchema();
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS conflict_sets (
+        id                      TEXT PRIMARY KEY,
+        name                    TEXT NOT NULL,
+        translation_functor_id  TEXT NOT NULL,
+        entry_count             INTEGER NOT NULL DEFAULT 0,
+        status                  TEXT NOT NULL,
+        created_at              TEXT NOT NULL,
+        data                    TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_cs_functor ON conflict_sets (translation_functor_id);
+      CREATE INDEX IF NOT EXISTS idx_cs_status  ON conflict_sets (status);
+    `);
+  }
+
+  save(conflictSet: ConflictSet): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO conflict_sets
+        (id, name, translation_functor_id, entry_count, status, created_at, data)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      conflictSet.id,
+      conflictSet.name,
+      conflictSet.translationFunctorId,
+      conflictSet.entries.length,
+      conflictSet.status,
+      conflictSet.createdAt,
+      JSON.stringify(conflictSet)
+    );
+  }
+
+  get(id: string): ConflictSet | null {
+    const row = this.db.prepare(
+      'SELECT * FROM conflict_sets WHERE id = ?'
+    ).get(id) as ConflictSetRow | undefined;
+    return row ? rowToConflictSet(row) : null;
+  }
+
+  listByFunctor(functorId: string): ConflictSet[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM conflict_sets WHERE translation_functor_id = ? ORDER BY created_at'
+    ).all(functorId) as ConflictSetRow[];
+    return rows.map(rowToConflictSet);
+  }
+
+  listAll(limit = 100): ConflictSet[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM conflict_sets ORDER BY created_at LIMIT ?'
+    ).all(limit) as ConflictSetRow[];
+    return rows.map(rowToConflictSet);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/causal-learner/mcp-server/src/core/conflict-set.ts
+++ b/causal-learner/mcp-server/src/core/conflict-set.ts
@@ -1,0 +1,114 @@
+/**
+ * ConflictSet — v9 本体冲突集合
+ * implements: docs/current/ontology-federation-contract.md
+ *
+ * ConflictSet 收集同一实体在两个（或多个）本体下的不兼容描述。
+ * 每条 ConflictEntry 记录一对本体对同一 entityRef 的不同断言。
+ */
+
+import crypto from 'crypto';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 冲突类型 */
+export type ConflictKind =
+  | 'type_mismatch'      // 两个本体对同一实体赋予不同类型
+  | 'attribute_clash'    // 同一属性值不一致
+  | 'relation_missing'   // 一个本体有某关系，另一个没有
+  | 'concept_absent'     // 一个本体无对应概念
+  | 'semantic_divergence'; // 语义上无法对齐
+
+/** 单条冲突条目 */
+export interface ConflictEntry {
+  id: string;
+  /** 冲突实体（Atom ref 或 entityRef） */
+  entityRef: string;
+  /** 第一个本体 ID */
+  ontologyAId: string;
+  /** 第一个本体对该实体的描述（JSON 序列化） */
+  descriptionA: string;
+  /** 第二个本体 ID */
+  ontologyBId: string;
+  /** 第二个本体对该实体的描述（JSON 序列化） */
+  descriptionB: string;
+  /** 冲突类型 */
+  kind: ConflictKind;
+  /** 冲突说明 */
+  explanation: string;
+  /** 是否已解决 */
+  resolved: boolean;
+  /** 解决方式（resolved=true 时提供） */
+  resolution?: string;
+  createdAt: string;
+}
+
+/** 冲突集合 */
+export interface ConflictSet {
+  id: string;
+  name: string;
+  /** 本次冲突分析关联的 TranslationFunctor ID */
+  translationFunctorId: string;
+  /** 冲突条目列表（不变量 1：可为空，但不为 null） */
+  entries: ConflictEntry[];
+  createdAt: string;
+  createdBy: string;
+  status: 'draft' | 'current' | 'deprecated';
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateConflictSetInput {
+  id?: string;
+  name: string;
+  translationFunctorId: string;
+  entries?: ConflictEntry[];
+  createdBy?: string;
+  status?: ConflictSet['status'];
+}
+
+export function createConflictSet(input: CreateConflictSetInput): ConflictSet {
+  return {
+    id:                   input.id ?? `CS_${crypto.randomBytes(6).toString('hex')}`,
+    name:                 input.name,
+    translationFunctorId: input.translationFunctorId,
+    entries:              input.entries ?? [],
+    createdAt:            new Date().toISOString(),
+    createdBy:            input.createdBy ?? 'system',
+    status:               input.status ?? 'draft',
+  };
+}
+
+/** 向 ConflictSet 追加一条冲突条目（immutable update） */
+export function appendConflictEntry(
+  conflictSet: ConflictSet,
+  entry: Omit<ConflictEntry, 'id' | 'createdAt' | 'resolved'>
+): ConflictSet {
+  const newEntry: ConflictEntry = {
+    id:           `CE_${crypto.randomBytes(6).toString('hex')}`,
+    resolved:     false,
+    createdAt:    new Date().toISOString(),
+    ...entry,
+  };
+  return {
+    ...conflictSet,
+    entries: [...conflictSet.entries, newEntry],
+  };
+}
+
+/** 标记某条冲突条目为已解决 */
+export function resolveConflictEntry(
+  conflictSet: ConflictSet,
+  entryId: string,
+  resolution: string
+): ConflictSet {
+  return {
+    ...conflictSet,
+    entries: conflictSet.entries.map(e =>
+      e.id === entryId ? { ...e, resolved: true, resolution } : e
+    ),
+  };
+}

--- a/causal-learner/mcp-server/src/core/ontology-model-store.ts
+++ b/causal-learner/mcp-server/src/core/ontology-model-store.ts
@@ -1,0 +1,93 @@
+/**
+ * OntologyModelStore — SQLite 持久化层
+ */
+
+import Database, { Database as DatabaseType } from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { OntologyModel } from './ontology-model.js';
+
+interface OntologyModelRow {
+  id: string;
+  name: string;
+  version: string;
+  is_canonical: number;
+  status: string;
+  created_at: string;
+  data: string;
+}
+
+function rowToModel(row: OntologyModelRow): OntologyModel {
+  return JSON.parse(row.data) as OntologyModel;
+}
+
+export class OntologyModelStore {
+  private db: DatabaseType;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ':memory:') {
+      const dir = path.dirname(dbPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    }
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.initSchema();
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS ontology_models (
+        id           TEXT PRIMARY KEY,
+        name         TEXT NOT NULL,
+        version      TEXT NOT NULL,
+        is_canonical INTEGER NOT NULL DEFAULT 0,
+        status       TEXT NOT NULL,
+        created_at   TEXT NOT NULL,
+        data         TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_om_status ON ontology_models (status);
+      CREATE INDEX IF NOT EXISTS idx_om_name   ON ontology_models (name);
+    `);
+  }
+
+  save(model: OntologyModel): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO ontology_models
+        (id, name, version, is_canonical, status, created_at, data)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      model.id,
+      model.name,
+      model.version,
+      model.isCanonical ? 1 : 0,
+      model.status,
+      model.createdAt,
+      JSON.stringify(model)
+    );
+  }
+
+  get(id: string): OntologyModel | null {
+    const row = this.db.prepare(
+      'SELECT * FROM ontology_models WHERE id = ?'
+    ).get(id) as OntologyModelRow | undefined;
+    return row ? rowToModel(row) : null;
+  }
+
+  listAll(limit = 100): OntologyModel[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM ontology_models ORDER BY created_at LIMIT ?'
+    ).all(limit) as OntologyModelRow[];
+    return rows.map(rowToModel);
+  }
+
+  listCanonical(): OntologyModel[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM ontology_models WHERE is_canonical = 1 ORDER BY created_at'
+    ).all() as OntologyModelRow[];
+    return rows.map(rowToModel);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/causal-learner/mcp-server/src/core/ontology-model.ts
+++ b/causal-learner/mcp-server/src/core/ontology-model.ts
@@ -1,0 +1,89 @@
+/**
+ * OntologyModel — v9 本体模型对象
+ * implements: docs/current/ontology-federation-contract.md
+ *
+ * 一个 OntologyModel 代表一套完整的概念体系：
+ * 描述实体类型、关系类型、属性类型，以及该本体的适用范围。
+ * 不同 Agent/Observer 可持有不同 OntologyModel 描述同一世界。
+ */
+
+import crypto from 'crypto';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 本体中的概念条目 */
+export interface OntologyConcept {
+  /** 本体内唯一标识 */
+  localId: string;
+  /** 概念类型：实体、关系、属性 */
+  kind: 'entity' | 'relation' | 'attribute';
+  /** 人类可读标签 */
+  label: string;
+  /** 概念描述 */
+  description?: string;
+  /** 父概念（本体内继承关系） */
+  parentLocalId?: string;
+}
+
+/** 本体模型 */
+export interface OntologyModel {
+  id: string;
+  name: string;
+  description: string;
+  /** 版本标识 */
+  version: string;
+  /** 该本体的概念集（不变量 1：至少一个概念） */
+  concepts: OntologyConcept[];
+  /** 适用范围描述（领域、上下文） */
+  applicabilityScope: string[];
+  /** 是否为权威本体（true = 用于仲裁冲突） */
+  isCanonical: boolean;
+  createdAt: string;
+  createdBy: string;
+  status: 'draft' | 'current' | 'deprecated';
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateOntologyModelInput {
+  id?: string;
+  name: string;
+  description: string;
+  version?: string;
+  concepts: OntologyConcept[];
+  applicabilityScope?: string[];
+  isCanonical?: boolean;
+  createdBy?: string;
+  status?: OntologyModel['status'];
+}
+
+export function createOntologyModel(input: CreateOntologyModelInput): OntologyModel {
+  // 不变量 1：concepts 非空
+  if (!input.concepts || input.concepts.length === 0) {
+    throw new Error('OntologyModel 不变量 1：concepts 不可为空');
+  }
+
+  // 不变量 2：localId 在 concepts 内唯一
+  const ids = input.concepts.map(c => c.localId);
+  const uniqueIds = new Set(ids);
+  if (uniqueIds.size !== ids.length) {
+    throw new Error('OntologyModel 不变量 2：concepts.localId 必须唯一');
+  }
+
+  return {
+    id:                 input.id ?? `OM_${crypto.randomBytes(6).toString('hex')}`,
+    name:               input.name,
+    description:        input.description,
+    version:            input.version ?? '1.0.0',
+    concepts:           input.concepts,
+    applicabilityScope: input.applicabilityScope ?? [],
+    isCanonical:        input.isCanonical ?? false,
+    createdAt:          new Date().toISOString(),
+    createdBy:          input.createdBy ?? 'system',
+    status:             input.status ?? 'draft',
+  };
+}

--- a/causal-learner/mcp-server/src/core/translation-functor.ts
+++ b/causal-learner/mcp-server/src/core/translation-functor.ts
@@ -1,0 +1,186 @@
+/**
+ * TranslationFunctor — v9 跨本体翻译函子
+ * implements: docs/current/ontology-federation-contract.md
+ *
+ * TranslationFunctor 在两个 OntologyModel 之间映射 Atom（概念实例）。
+ * 若映射不完整则返回 null，冲突记录到 ConflictSet。
+ */
+
+import crypto from 'crypto';
+import type { OntologyModel, OntologyConcept } from './ontology-model.js';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 单条概念映射规则 */
+export interface ConceptMapping {
+  /** 源本体的 localId */
+  sourceConceptId: string;
+  /** 目标本体的 localId */
+  targetConceptId: string;
+  /** 映射置信度 [0, 1] */
+  confidence: number;
+  /** 映射说明 */
+  rationale?: string;
+}
+
+/** 翻译结果 */
+export interface TranslationResult {
+  /** 原始 Atom ref */
+  sourceRef: string;
+  /** 翻译后的 Atom ref（null = 无法映射） */
+  translatedRef: string | null;
+  /** 实际使用的映射规则 */
+  appliedMapping: ConceptMapping | null;
+  /** 翻译是否成功 */
+  success: boolean;
+  /** 失败原因（成功时为 undefined） */
+  failReason?: string;
+}
+
+/** 翻译函子 */
+export interface TranslationFunctor {
+  id: string;
+  name: string;
+  /** 源本体 ID */
+  sourceOntologyId: string;
+  /** 目标本体 ID */
+  targetOntologyId: string;
+  /** 映射规则集（不变量 1：至少一条） */
+  mappings: ConceptMapping[];
+  /** 默认行为：映射失败时是否报错（false = 返回 null） */
+  strictMode: boolean;
+  createdAt: string;
+  createdBy: string;
+  status: 'draft' | 'current' | 'deprecated';
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateTranslationFunctorInput {
+  id?: string;
+  name: string;
+  sourceOntologyId: string;
+  targetOntologyId: string;
+  mappings: ConceptMapping[];
+  strictMode?: boolean;
+  createdBy?: string;
+  status?: TranslationFunctor['status'];
+}
+
+export function createTranslationFunctor(
+  input: CreateTranslationFunctorInput
+): TranslationFunctor {
+  // 不变量 1：mappings 非空
+  if (!input.mappings || input.mappings.length === 0) {
+    throw new Error('TranslationFunctor 不变量 1：mappings 不可为空');
+  }
+  // 不变量 2：源本体和目标本体不能相同
+  if (input.sourceOntologyId === input.targetOntologyId) {
+    throw new Error('TranslationFunctor 不变量 2：sourceOntologyId 与 targetOntologyId 不可相同');
+  }
+  // 不变量 3：confidence 必须在 [0,1]
+  for (const m of input.mappings) {
+    if (m.confidence < 0 || m.confidence > 1) {
+      throw new Error(
+        `TranslationFunctor 不变量 3：mapping "${m.sourceConceptId}" → "${m.targetConceptId}" 的 confidence 必须在 [0,1]`
+      );
+    }
+  }
+
+  return {
+    id:                input.id ?? `TF_${crypto.randomBytes(6).toString('hex')}`,
+    name:              input.name,
+    sourceOntologyId:  input.sourceOntologyId,
+    targetOntologyId:  input.targetOntologyId,
+    mappings:          input.mappings,
+    strictMode:        input.strictMode ?? false,
+    createdAt:         new Date().toISOString(),
+    createdBy:         input.createdBy ?? 'system',
+    status:            input.status ?? 'draft',
+  };
+}
+
+// =============================================================================
+// 翻译执行
+// =============================================================================
+
+/**
+ * 将一个 Atom ref（格式：`<conceptLocalId>:<instanceId>`）从源本体翻译到目标本体。
+ *
+ * @param functor  翻译函子
+ * @param sourceRef  源 Atom ref（格式 `conceptLocalId:instanceId` 或纯 conceptLocalId）
+ * @param sourceOntology  源 OntologyModel（用于验证 conceptLocalId 是否存在）
+ * @param targetOntology  目标 OntologyModel（用于验证 targetConceptId 是否存在）
+ * @returns TranslationResult
+ */
+export function translateAtomRef(
+  functor: TranslationFunctor,
+  sourceRef: string,
+  sourceOntology: OntologyModel,
+  targetOntology: OntologyModel
+): TranslationResult {
+  // 解析 sourceRef
+  const [conceptLocalId, instanceId] = sourceRef.includes(':')
+    ? sourceRef.split(':', 2)
+    : [sourceRef, undefined];
+
+  // 验证源概念存在
+  const sourceConcept: OntologyConcept | undefined = sourceOntology.concepts.find(
+    c => c.localId === conceptLocalId
+  );
+  if (!sourceConcept) {
+    return {
+      sourceRef,
+      translatedRef: null,
+      appliedMapping: null,
+      success: false,
+      failReason: `源本体 "${sourceOntology.id}" 中不存在概念 "${conceptLocalId}"`,
+    };
+  }
+
+  // 查找映射规则（取置信度最高的）
+  const candidates = functor.mappings
+    .filter(m => m.sourceConceptId === conceptLocalId)
+    .sort((a, b) => b.confidence - a.confidence);
+
+  const mapping = candidates[0] ?? null;
+
+  if (!mapping) {
+    return {
+      sourceRef,
+      translatedRef: null,
+      appliedMapping: null,
+      success: false,
+      failReason: `翻译函子中无 "${conceptLocalId}" 的映射规则`,
+    };
+  }
+
+  // 验证目标概念存在
+  const targetConcept: OntologyConcept | undefined = targetOntology.concepts.find(
+    c => c.localId === mapping.targetConceptId
+  );
+  if (!targetConcept) {
+    return {
+      sourceRef,
+      translatedRef: null,
+      appliedMapping: mapping,
+      success: false,
+      failReason: `目标本体 "${targetOntology.id}" 中不存在概念 "${mapping.targetConceptId}"`,
+    };
+  }
+
+  const translatedRef = instanceId
+    ? `${mapping.targetConceptId}:${instanceId}`
+    : mapping.targetConceptId;
+
+  return {
+    sourceRef,
+    translatedRef,
+    appliedMapping: mapping,
+    success: true,
+  };
+}

--- a/causal-learner/mcp-server/src/tests/v9-ontology-federation.test.ts
+++ b/causal-learner/mcp-server/src/tests/v9-ontology-federation.test.ts
@@ -1,0 +1,377 @@
+/**
+ * v9 OntologyFederation 测试
+ * 覆盖：OntologyModel 工厂 + 不变量、TranslationFunctor 翻译逻辑、ConflictSet CRUD
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createOntologyModel } from '../core/ontology-model.js';
+import {
+  createTranslationFunctor,
+  translateAtomRef,
+} from '../core/translation-functor.js';
+import {
+  createConflictSet,
+  appendConflictEntry,
+  resolveConflictEntry,
+} from '../core/conflict-set.js';
+import { OntologyModelStore } from '../core/ontology-model-store.js';
+import { ConflictSetStore } from '../core/conflict-set-store.js';
+
+// =============================================================================
+// 测试夹具
+// =============================================================================
+
+/** 医学本体（源） */
+const medicalOntology = createOntologyModel({
+  id: 'OM_medical',
+  name: '医学本体',
+  description: '以疾病、症状、治疗为核心概念的医学本体',
+  version: '1.0.0',
+  concepts: [
+    { localId: 'Disease',   kind: 'entity',    label: '疾病' },
+    { localId: 'Symptom',   kind: 'entity',    label: '症状' },
+    { localId: 'Treatment', kind: 'entity',    label: '治疗' },
+    { localId: 'causes',    kind: 'relation',  label: '导致' },
+    { localId: 'severity',  kind: 'attribute', label: '严重程度' },
+  ],
+  applicabilityScope: ['临床诊断', '病历分析'],
+  isCanonical: true,
+});
+
+/** 工程本体（目标） */
+const engineeringOntology = createOntologyModel({
+  id: 'OM_engineering',
+  name: '工程本体',
+  description: '以组件、故障、维修为核心概念的工程本体',
+  version: '1.0.0',
+  concepts: [
+    { localId: 'Component', kind: 'entity',    label: '组件' },
+    { localId: 'Failure',   kind: 'entity',    label: '故障' },
+    { localId: 'Repair',    kind: 'entity',    label: '维修' },
+    { localId: 'results_in', kind: 'relation', label: '导致' },
+    { localId: 'severity',  kind: 'attribute', label: '严重程度' },
+  ],
+  applicabilityScope: ['设备维护', '故障分析'],
+});
+
+/** 医学 → 工程翻译函子 */
+const med2engFunctor = createTranslationFunctor({
+  id: 'TF_med_to_eng',
+  name: '医学→工程翻译',
+  sourceOntologyId: 'OM_medical',
+  targetOntologyId: 'OM_engineering',
+  mappings: [
+    { sourceConceptId: 'Disease',   targetConceptId: 'Failure',    confidence: 0.85 },
+    { sourceConceptId: 'Symptom',   targetConceptId: 'Failure',    confidence: 0.60 },
+    { sourceConceptId: 'Treatment', targetConceptId: 'Repair',     confidence: 0.90 },
+    { sourceConceptId: 'causes',    targetConceptId: 'results_in', confidence: 0.95 },
+    { sourceConceptId: 'severity',  targetConceptId: 'severity',   confidence: 1.00 },
+  ],
+});
+
+// =============================================================================
+// OntologyModel 工厂 + 不变量
+// =============================================================================
+
+describe('OntologyModel', () => {
+  it('正常创建并校验字段', () => {
+    assert.equal(medicalOntology.id, 'OM_medical');
+    assert.equal(medicalOntology.concepts.length, 5);
+    assert.equal(medicalOntology.isCanonical, true);
+    assert.equal(medicalOntology.status, 'draft');
+  });
+
+  it('不变量 I1：concepts 为空时抛出', () => {
+    assert.throws(
+      () => createOntologyModel({ name: 'empty', description: '', concepts: [] }),
+      /不变量 1/
+    );
+  });
+
+  it('不变量 I2：localId 重复时抛出', () => {
+    assert.throws(
+      () => createOntologyModel({
+        name: 'dup',
+        description: '',
+        concepts: [
+          { localId: 'X', kind: 'entity', label: 'X' },
+          { localId: 'X', kind: 'entity', label: 'X dup' },
+        ],
+      }),
+      /不变量 2/
+    );
+  });
+
+  it('isCanonical 默认为 false', () => {
+    assert.equal(engineeringOntology.isCanonical, false);
+  });
+});
+
+// =============================================================================
+// TranslationFunctor 工厂 + 翻译执行
+// =============================================================================
+
+describe('TranslationFunctor', () => {
+  it('正常创建并校验字段', () => {
+    assert.equal(med2engFunctor.id, 'TF_med_to_eng');
+    assert.equal(med2engFunctor.mappings.length, 5);
+    assert.equal(med2engFunctor.sourceOntologyId, 'OM_medical');
+    assert.equal(med2engFunctor.targetOntologyId, 'OM_engineering');
+  });
+
+  it('不变量 I1：mappings 为空时抛出', () => {
+    assert.throws(
+      () => createTranslationFunctor({
+        name: 'empty',
+        sourceOntologyId: 'A',
+        targetOntologyId: 'B',
+        mappings: [],
+      }),
+      /不变量 1/
+    );
+  });
+
+  it('不变量 I2：源目标相同时抛出', () => {
+    assert.throws(
+      () => createTranslationFunctor({
+        name: 'self',
+        sourceOntologyId: 'A',
+        targetOntologyId: 'A',
+        mappings: [{ sourceConceptId: 'X', targetConceptId: 'X', confidence: 1 }],
+      }),
+      /不变量 2/
+    );
+  });
+
+  it('不变量 I3：confidence 超出 [0,1] 时抛出', () => {
+    assert.throws(
+      () => createTranslationFunctor({
+        name: 'bad',
+        sourceOntologyId: 'A',
+        targetOntologyId: 'B',
+        mappings: [{ sourceConceptId: 'X', targetConceptId: 'Y', confidence: 1.5 }],
+      }),
+      /不变量 3/
+    );
+  });
+});
+
+describe('translateAtomRef', () => {
+  it('Disease:flu → Failure:flu（带 instanceId）', () => {
+    const result = translateAtomRef(
+      med2engFunctor,
+      'Disease:flu',
+      medicalOntology,
+      engineeringOntology
+    );
+    assert.equal(result.success, true);
+    assert.equal(result.translatedRef, 'Failure:flu');
+    assert.equal(result.appliedMapping?.confidence, 0.85);
+  });
+
+  it('Treatment（无 instanceId）→ Repair', () => {
+    const result = translateAtomRef(
+      med2engFunctor,
+      'Treatment',
+      medicalOntology,
+      engineeringOntology
+    );
+    assert.equal(result.success, true);
+    assert.equal(result.translatedRef, 'Repair');
+  });
+
+  it('severity → severity（同名属性，置信度 1.0）', () => {
+    const result = translateAtomRef(
+      med2engFunctor,
+      'severity:high',
+      medicalOntology,
+      engineeringOntology
+    );
+    assert.equal(result.success, true);
+    assert.equal(result.translatedRef, 'severity:high');
+    assert.equal(result.appliedMapping?.confidence, 1.0);
+  });
+
+  it('多规则取置信度最高：Symptom(0.60) vs Disease(0.85) — 各自独立，Symptom → Failure', () => {
+    const result = translateAtomRef(
+      med2engFunctor,
+      'Symptom:fever',
+      medicalOntology,
+      engineeringOntology
+    );
+    assert.equal(result.success, true);
+    assert.equal(result.translatedRef, 'Failure:fever');
+    assert.equal(result.appliedMapping?.confidence, 0.60);
+  });
+
+  it('源本体不存在的概念 → 翻译失败', () => {
+    const result = translateAtomRef(
+      med2engFunctor,
+      'UnknownConcept:x',
+      medicalOntology,
+      engineeringOntology
+    );
+    assert.equal(result.success, false);
+    assert.ok(result.failReason?.includes('不存在概念'));
+  });
+
+  it('无对应映射规则 → 翻译失败', () => {
+    // engineeringOntology 有 Component 但 functor 没有针对它的规则
+    const result = translateAtomRef(
+      med2engFunctor,
+      'Component:pump',
+      engineeringOntology,  // 故意传工程本体作为源，functor 的 source 是 medical
+      engineeringOntology
+    );
+    assert.equal(result.success, false);
+  });
+});
+
+// =============================================================================
+// ConflictSet CRUD
+// =============================================================================
+
+describe('ConflictSet', () => {
+  it('createConflictSet：初始 entries 为空', () => {
+    const cs = createConflictSet({
+      name: '医学-工程冲突集',
+      translationFunctorId: 'TF_med_to_eng',
+    });
+    assert.equal(cs.entries.length, 0);
+    assert.ok(cs.id.startsWith('CS_'));
+  });
+
+  it('appendConflictEntry：追加冲突条目', () => {
+    const cs = createConflictSet({
+      name: '测试冲突集',
+      translationFunctorId: 'TF_med_to_eng',
+    });
+    const cs2 = appendConflictEntry(cs, {
+      entityRef: 'Disease:flu',
+      ontologyAId: 'OM_medical',
+      descriptionA: JSON.stringify({ type: 'Disease', label: '流感' }),
+      ontologyBId: 'OM_engineering',
+      descriptionB: JSON.stringify({ type: 'Component', label: '组件' }),
+      kind: 'type_mismatch',
+      explanation: '医学本体将 flu 视为疾病，工程本体无直接对应',
+    });
+    assert.equal(cs2.entries.length, 1);
+    assert.equal(cs2.entries[0].resolved, false);
+    assert.equal(cs2.entries[0].kind, 'type_mismatch');
+  });
+
+  it('appendConflictEntry 是 immutable update（原 cs 不变）', () => {
+    const cs = createConflictSet({ name: 'cs', translationFunctorId: 'TF_x' });
+    const cs2 = appendConflictEntry(cs, {
+      entityRef: 'A',
+      ontologyAId: 'O1',
+      descriptionA: '{}',
+      ontologyBId: 'O2',
+      descriptionB: '{}',
+      kind: 'concept_absent',
+      explanation: 'test',
+    });
+    assert.equal(cs.entries.length, 0);  // 原对象不变
+    assert.equal(cs2.entries.length, 1);
+  });
+
+  it('resolveConflictEntry：标记已解决', () => {
+    let cs = createConflictSet({ name: 'cs', translationFunctorId: 'TF_x' });
+    cs = appendConflictEntry(cs, {
+      entityRef: 'X',
+      ontologyAId: 'O1',
+      descriptionA: '{}',
+      ontologyBId: 'O2',
+      descriptionB: '{}',
+      kind: 'attribute_clash',
+      explanation: '属性值不一致',
+    });
+    const entryId = cs.entries[0].id;
+    const cs3 = resolveConflictEntry(cs, entryId, '以 OM_medical 为权威本体');
+    assert.equal(cs3.entries[0].resolved, true);
+    assert.equal(cs3.entries[0].resolution, '以 OM_medical 为权威本体');
+  });
+});
+
+// =============================================================================
+// OntologyModelStore 持久化
+// =============================================================================
+
+describe('OntologyModelStore', () => {
+  it('save + get 往返一致', () => {
+    const store = new OntologyModelStore(':memory:');
+    store.save(medicalOntology);
+    const retrieved = store.get('OM_medical');
+    assert.ok(retrieved !== null);
+    assert.equal(retrieved.name, '医学本体');
+    assert.equal(retrieved.concepts.length, 5);
+    store.close();
+  });
+
+  it('listAll 返回已保存对象', () => {
+    const store = new OntologyModelStore(':memory:');
+    store.save(medicalOntology);
+    store.save(engineeringOntology);
+    const all = store.listAll();
+    assert.equal(all.length, 2);
+    store.close();
+  });
+
+  it('listCanonical 只返回 isCanonical=true 的对象', () => {
+    const store = new OntologyModelStore(':memory:');
+    store.save(medicalOntology);      // isCanonical: true
+    store.save(engineeringOntology);  // isCanonical: false
+    const canonical = store.listCanonical();
+    assert.equal(canonical.length, 1);
+    assert.equal(canonical[0].id, 'OM_medical');
+    store.close();
+  });
+
+  it('get 不存在 ID 返回 null', () => {
+    const store = new OntologyModelStore(':memory:');
+    assert.equal(store.get('OM_nonexistent'), null);
+    store.close();
+  });
+});
+
+// =============================================================================
+// ConflictSetStore 持久化
+// =============================================================================
+
+describe('ConflictSetStore', () => {
+  it('save + get 往返一致', () => {
+    const store = new ConflictSetStore(':memory:');
+    let cs = createConflictSet({
+      id: 'CS_test',
+      name: '测试集',
+      translationFunctorId: 'TF_med_to_eng',
+    });
+    cs = appendConflictEntry(cs, {
+      entityRef: 'Disease:flu',
+      ontologyAId: 'OM_medical',
+      descriptionA: '{}',
+      ontologyBId: 'OM_engineering',
+      descriptionB: '{}',
+      kind: 'type_mismatch',
+      explanation: 'test',
+    });
+    store.save(cs);
+    const retrieved = store.get('CS_test');
+    assert.ok(retrieved !== null);
+    assert.equal(retrieved.entries.length, 1);
+    store.close();
+  });
+
+  it('listByFunctor 按 functorId 过滤', () => {
+    const store = new ConflictSetStore(':memory:');
+    const cs1 = createConflictSet({ id: 'CS_a', name: 'a', translationFunctorId: 'TF_1' });
+    const cs2 = createConflictSet({ id: 'CS_b', name: 'b', translationFunctorId: 'TF_2' });
+    store.save(cs1);
+    store.save(cs2);
+    const result = store.listByFunctor('TF_1');
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'CS_a');
+    store.close();
+  });
+});

--- a/docs/current/ontology-federation-contract.md
+++ b/docs/current/ontology-federation-contract.md
@@ -1,0 +1,101 @@
+# OntologyFederation Contract — v9
+
+**状态**: draft  
+**版本**: v9.0  
+**依赖**: v7 world-model-contract, v8 mechanism-program-contract
+
+---
+
+## 1. 动机
+
+v8 假设世界只有一套本体描述。v9 引入本体联邦：不同 Agent、Observer 或领域可以用不同的概念体系（OntologyModel）描述同一世界。OntologyFederation 提供跨本体翻译和冲突检测机制。
+
+---
+
+## 2. 核心对象
+
+### 2.1 OntologyModel
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`OM_<hex>`） |
+| `name` | string | 本体名称 |
+| `version` | string | 语义化版本 |
+| `concepts` | `OntologyConcept[]` | 概念集合（**不变量 I1：至少一个**） |
+| `applicabilityScope` | string[] | 适用范围描述 |
+| `isCanonical` | boolean | 是否为权威本体 |
+
+**不变量**
+
+- **OM-I1**: `concepts` 非空
+- **OM-I2**: `concepts[].localId` 在同一本体内唯一
+
+### 2.2 TranslationFunctor
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`TF_<hex>`） |
+| `sourceOntologyId` | string | 源本体 |
+| `targetOntologyId` | string | 目标本体 |
+| `mappings` | `ConceptMapping[]` | 映射规则（**不变量 I1：至少一条**） |
+| `strictMode` | boolean | 映射失败是否报错 |
+
+**不变量**
+
+- **TF-I1**: `mappings` 非空
+- **TF-I2**: `sourceOntologyId ≠ targetOntologyId`
+- **TF-I3**: `mapping.confidence ∈ [0,1]`
+
+**执行语义** (`translateAtomRef`)
+
+1. 解析 `sourceRef` 为 `(conceptLocalId, instanceId?)`
+2. 验证 `conceptLocalId` 存在于源本体
+3. 选取 `sourceConceptId === conceptLocalId` 且置信度最高的映射规则
+4. 验证 `targetConceptId` 存在于目标本体
+5. 返回 `TranslationResult`（成功/失败原因）
+
+### 2.3 ConflictSet
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`CS_<hex>`） |
+| `translationFunctorId` | string | 关联函子 |
+| `entries` | `ConflictEntry[]` | 冲突条目（可为空数组） |
+
+**ConflictEntry 字段**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `entityRef` | string | 冲突实体 ref |
+| `ontologyAId` / `ontologyBId` | string | 两个本体 |
+| `descriptionA` / `descriptionB` | string | 各本体的描述（JSON） |
+| `kind` | ConflictKind | 冲突类型枚举 |
+| `resolved` | boolean | 是否已解决 |
+
+---
+
+## 3. 操作
+
+| 操作 | 函数 | 说明 |
+|------|------|------|
+| 翻译 Atom ref | `translateAtomRef(functor, ref, srcOM, tgtOM)` | 返回 TranslationResult |
+| 追加冲突条目 | `appendConflictEntry(cs, entry)` | immutable update |
+| 标记冲突解决 | `resolveConflictEntry(cs, entryId, resolution)` | immutable update |
+
+---
+
+## 4. 存储
+
+| 对象 | Store 类 | 表名 |
+|------|----------|------|
+| OntologyModel | `OntologyModelStore` | `ontology_models` |
+| ConflictSet | `ConflictSetStore` | `conflict_sets` |
+| TranslationFunctor | 内存（暂无持久化） | — |
+
+---
+
+## 5. 设计决策
+
+- **TranslationFunctor 暂无 store**：函子是轻量规则集，首轮可内存持有，v9.1 再持久化。
+- **ConflictSet 是 append-only 追加语义**：通过 `appendConflictEntry` 追加，不修改已有条目；解决通过 `resolveConflictEntry` 标记。
+- **多映射规则取置信度最高**：当一个 sourceConceptId 有多条映射规则时，`translateAtomRef` 取 confidence 最高者。


### PR DESCRIPTION
## 实现内容

v9 本体联邦基础对象，支持多本体并存、跨本体翻译和冲突检测。

### 新增文件

| 文件 | 说明 |
|------|------|
| `src/core/ontology-model.ts` | OntologyModel 类型 + 工厂（不变量 I1/I2） |
| `src/core/ontology-model-store.ts` | SQLite 持久化 + listCanonical |
| `src/core/translation-functor.ts` | TranslationFunctor + translateAtomRef 执行逻辑 |
| `src/core/conflict-set.ts` | ConflictSet + immutable append/resolve |
| `src/core/conflict-set-store.ts` | SQLite 持久化 + listByFunctor |
| `src/tests/v9-ontology-federation.test.ts` | 24 个测试 |
| `docs/current/ontology-federation-contract.md` | draft 合约 |

### 测试结果

```
ℹ tests 62
ℹ pass 62
ℹ fail 0
```

Closes #26
Closes #27