### PR TITLE
feat: v10 ParticipativeWorld — ObserverModel + InstitutionModel

### DIFF
--- a/causal-learner/mcp-server/src/core/institution-model.ts
+++ b/causal-learner/mcp-server/src/core/institution-model.ts
@@ -1,0 +1,176 @@
+/**
+ * InstitutionModel — v10 制度模型
+ * implements: docs/current/participatory-world-contract.md
+ *
+ * InstitutionModel 描述参与者所处的制度约束和角色分配。
+ * 制度约束限制哪些动作合法，角色分配决定哪些 Agent 有权观测或干预。
+ */
+
+import crypto from 'crypto';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 制度规则 */
+export interface InstitutionRule {
+  id: string;
+  /** 规则描述 */
+  description: string;
+  /** 受约束的动作类型 */
+  constrainedActionKind: string;
+  /** 允许执行该动作的角色列表（空数组 = 所有角色均可） */
+  allowedRoles: string[];
+  /** 禁止执行该动作的角色列表 */
+  forbiddenRoles: string[];
+  /** 规则优先级（数字越大越优先） */
+  priority: number;
+}
+
+/** 角色分配条目 */
+export interface RoleAssignment {
+  /** Agent / Observer ref */
+  agentRef: string;
+  /** 分配的角色 */
+  role: string;
+  /** 有效期（ISO 8601，可选） */
+  validUntil?: string;
+}
+
+/** 制度模型 */
+export interface InstitutionModel {
+  id: string;
+  name: string;
+  description: string;
+  /** 制度规则集（不变量 I1：至少一条规则） */
+  rules: InstitutionRule[];
+  /** 角色分配列表（可为空） */
+  roleAssignments: RoleAssignment[];
+  /** 制度所属的本体 ID（可选，v9 联邦上下文） */
+  ontologyId?: string;
+  createdAt: string;
+  createdBy: string;
+  status: 'draft' | 'current' | 'deprecated';
+}
+
+/** 权限检查结果 */
+export interface PermissionCheckResult {
+  allowed: boolean;
+  /** 命中的规则（allowed=false 时为禁止规则） */
+  matchedRule: InstitutionRule | null;
+  reason: string;
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateInstitutionModelInput {
+  id?: string;
+  name: string;
+  description: string;
+  rules: InstitutionRule[];
+  roleAssignments?: RoleAssignment[];
+  ontologyId?: string;
+  createdBy?: string;
+  status?: InstitutionModel['status'];
+}
+
+export function createInstitutionModel(
+  input: CreateInstitutionModelInput
+): InstitutionModel {
+  // 不变量 I1：rules 非空
+  if (!input.rules || input.rules.length === 0) {
+    throw new Error('InstitutionModel 不变量 I1：rules 不可为空');
+  }
+
+  return {
+    id:              input.id ?? `IM_${crypto.randomBytes(6).toString('hex')}`,
+    name:            input.name,
+    description:     input.description,
+    rules:           input.rules,
+    roleAssignments: input.roleAssignments ?? [],
+    ontologyId:      input.ontologyId,
+    createdAt:       new Date().toISOString(),
+    createdBy:       input.createdBy ?? 'system',
+    status:          input.status ?? 'draft',
+  };
+}
+
+// =============================================================================
+// 权限检查
+// =============================================================================
+
+/**
+ * 检查某个 Agent 是否有权执行特定动作类型。
+ * 逻辑：
+ * 1. 从 roleAssignments 中找到该 Agent 的角色列表
+ * 2. 在 rules 中找所有 constrainedActionKind 匹配的规则，按 priority 降序排序
+ * 3. 若某条规则的 forbiddenRoles 包含该 Agent 的任意角色 → 拒绝
+ * 4. 若某条规则的 allowedRoles 非空且包含该 Agent 的任意角色 → 允许
+ * 5. 若某条规则的 allowedRoles 为空（所有角色均可） → 允许
+ * 6. 无匹配规则 → 默认允许（开放世界假设）
+ *
+ * @param institution   InstitutionModel
+ * @param agentRef      Agent ref
+ * @param actionKind    动作类型
+ * @returns PermissionCheckResult
+ */
+export function checkRolePermission(
+  institution: InstitutionModel,
+  agentRef: string,
+  actionKind: string
+): PermissionCheckResult {
+  // 找出该 Agent 的所有角色
+  const agentRoles = institution.roleAssignments
+    .filter(ra => ra.agentRef === agentRef)
+    .map(ra => ra.role);
+
+  // 找到匹配 actionKind 的规则，priority 降序
+  const matchingRules = institution.rules
+    .filter(r => r.constrainedActionKind === actionKind)
+    .sort((a, b) => b.priority - a.priority);
+
+  for (const rule of matchingRules) {
+    // 检查禁止列表（优先于允许列表）
+    const isForbidden = rule.forbiddenRoles.some(fr => agentRoles.includes(fr));
+    if (isForbidden) {
+      return {
+        allowed: false,
+        matchedRule: rule,
+        reason: `Agent "${agentRef}" 的角色被规则 "${rule.id}" 禁止执行 "${actionKind}"`,
+      };
+    }
+
+    // 检查允许列表
+    if (rule.allowedRoles.length === 0) {
+      // 所有角色均可
+      return {
+        allowed: true,
+        matchedRule: rule,
+        reason: `规则 "${rule.id}" 允许所有角色执行 "${actionKind}"`,
+      };
+    }
+    const isAllowed = rule.allowedRoles.some(ar => agentRoles.includes(ar));
+    if (isAllowed) {
+      return {
+        allowed: true,
+        matchedRule: rule,
+        reason: `Agent "${agentRef}" 的角色满足规则 "${rule.id}" 的允许条件`,
+      };
+    }
+    // allowedRoles 非空但 agent 角色不在其中 → 此规则明确拒绝
+    return {
+      allowed: false,
+      matchedRule: rule,
+      reason: `Agent "${agentRef}" 的角色不在规则 "${rule.id}" 的允许角色列表中`,
+    };
+  }
+
+  // 无匹配规则 → 默认允许
+  return {
+    allowed: true,
+    matchedRule: null,
+    reason: `无约束规则匹配 "${actionKind}"，默认允许`,
+  };
+}

--- a/causal-learner/mcp-server/src/core/observer-model-store.ts
+++ b/causal-learner/mcp-server/src/core/observer-model-store.ts
@@ -1,0 +1,82 @@
+/**
+ * ObserverModelStore — SQLite 持久化层
+ */
+
+import Database, { Database as DatabaseType } from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ObserverModel } from './observer-model.js';
+
+interface ObserverModelRow {
+  id: string;
+  name: string;
+  position: string;
+  status: string;
+  created_at: string;
+  data: string;
+}
+
+function rowToModel(row: ObserverModelRow): ObserverModel {
+  return JSON.parse(row.data) as ObserverModel;
+}
+
+export class ObserverModelStore {
+  private db: DatabaseType;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ':memory:') {
+      const dir = path.dirname(dbPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    }
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.initSchema();
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS observer_models (
+        id         TEXT PRIMARY KEY,
+        name       TEXT NOT NULL,
+        position   TEXT NOT NULL,
+        status     TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        data       TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_obs_status ON observer_models (status);
+    `);
+  }
+
+  save(model: ObserverModel): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO observer_models
+        (id, name, position, status, created_at, data)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(
+      model.id,
+      model.name,
+      model.position,
+      model.status,
+      model.createdAt,
+      JSON.stringify(model)
+    );
+  }
+
+  get(id: string): ObserverModel | null {
+    const row = this.db.prepare(
+      'SELECT * FROM observer_models WHERE id = ?'
+    ).get(id) as ObserverModelRow | undefined;
+    return row ? rowToModel(row) : null;
+  }
+
+  listAll(limit = 100): ObserverModel[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM observer_models ORDER BY created_at LIMIT ?'
+    ).all(limit) as ObserverModelRow[];
+    return rows.map(rowToModel);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/causal-learner/mcp-server/src/core/observer-model.ts
+++ b/causal-learner/mcp-server/src/core/observer-model.ts
@@ -1,0 +1,149 @@
+/**
+ * ObserverModel — v10 观察者模型
+ * implements: docs/current/participatory-world-contract.md
+ *
+ * ObserverModel 描述一个观察者的位置、仪器偏差和盲区。
+ * 不同观察者看到的 ObservationRecord 可能因盲区而不同。
+ */
+
+import crypto from 'crypto';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 仪器偏差描述 */
+export interface InstrumentBias {
+  /** 受影响的信号 key（对应 ObservationModel.outputSignals.key） */
+  signalKey: string;
+  /** 偏差类型 */
+  biasKind: 'systematic' | 'random' | 'threshold' | 'saturation';
+  /** 偏差量（可为正负，systematic/threshold 时有意义） */
+  magnitude?: number;
+  /** 偏差说明 */
+  description: string;
+}
+
+/** 观察者模型 */
+export interface ObserverModel {
+  id: string;
+  name: string;
+  description: string;
+  /** 观察者位置（坐标、角色、层级等自由描述） */
+  position: string;
+  /** 仪器偏差列表（可为空数组） */
+  instrumentBiases: InstrumentBias[];
+  /**
+   * 盲区信号 key 列表（不变量 I1：可为空数组，但不为 null）
+   * 盲区内的信号在 filterObservations 时被过滤掉
+   */
+  blindZoneSignalKeys: string[];
+  /** 观察者所在的本体 ID（可选，v9 联邦上下文） */
+  ontologyId?: string;
+  createdAt: string;
+  createdBy: string;
+  status: 'draft' | 'current' | 'deprecated';
+}
+
+/** 观测过滤结果 */
+export interface FilteredObservation {
+  /** 原始信号 map（key → value） */
+  original: Record<string, unknown>;
+  /** 过滤后的信号 map（已移除盲区信号） */
+  filtered: Record<string, unknown>;
+  /** 被过滤掉的信号 key 列表 */
+  removedKeys: string[];
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateObserverModelInput {
+  id?: string;
+  name: string;
+  description: string;
+  position: string;
+  instrumentBiases?: InstrumentBias[];
+  blindZoneSignalKeys?: string[];
+  ontologyId?: string;
+  createdBy?: string;
+  status?: ObserverModel['status'];
+}
+
+export function createObserverModel(input: CreateObserverModelInput): ObserverModel {
+  return {
+    id:                   input.id ?? `OBS_${crypto.randomBytes(6).toString('hex')}`,
+    name:                 input.name,
+    description:          input.description,
+    position:             input.position,
+    instrumentBiases:     input.instrumentBiases     ?? [],
+    blindZoneSignalKeys:  input.blindZoneSignalKeys  ?? [],
+    ontologyId:           input.ontologyId,
+    createdAt:            new Date().toISOString(),
+    createdBy:            input.createdBy            ?? 'system',
+    status:               input.status               ?? 'draft',
+  };
+}
+
+// =============================================================================
+// 观测过滤
+// =============================================================================
+
+/**
+ * 根据观察者盲区过滤信号 map。
+ * 盲区内的信号 key 被从 filtered 中移除，但记录在 removedKeys 中。
+ *
+ * @param observer  ObserverModel
+ * @param signals   原始信号 map（key → value）
+ * @returns FilteredObservation
+ */
+export function filterObservations(
+  observer: ObserverModel,
+  signals: Record<string, unknown>
+): FilteredObservation {
+  const blindZone = new Set(observer.blindZoneSignalKeys);
+  const removedKeys: string[] = [];
+  const filtered: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(signals)) {
+    if (blindZone.has(key)) {
+      removedKeys.push(key);
+    } else {
+      filtered[key] = value;
+    }
+  }
+
+  return {
+    original: { ...signals },
+    filtered,
+    removedKeys,
+  };
+}
+
+/**
+ * 将观察者的仪器偏差应用到信号值（数值型信号）。
+ * systematic / threshold 偏差：在原始值上加上 magnitude。
+ * 非数值型信号或无对应偏差的信号不做修改。
+ *
+ * @param observer  ObserverModel
+ * @param signals   信号 map
+ * @returns 应用偏差后的信号 map（新对象）
+ */
+export function applyInstrumentBias(
+  observer: ObserverModel,
+  signals: Record<string, unknown>
+): Record<string, unknown> {
+  const result = { ...signals };
+  for (const bias of observer.instrumentBiases) {
+    const value = result[bias.signalKey];
+    if (
+      typeof value === 'number' &&
+      typeof bias.magnitude === 'number' &&
+      (bias.biasKind === 'systematic' || bias.biasKind === 'threshold')
+    ) {
+      result[bias.signalKey] = value + bias.magnitude;
+    }
+  }
+  return result;
+}

--- a/causal-learner/mcp-server/src/tests/v10-participatory-world.test.ts
+++ b/causal-learner/mcp-server/src/tests/v10-participatory-world.test.ts
@@ -1,0 +1,296 @@
+/**
+ * v10 ParticipativeWorld 测试
+ * 覆盖：ObserverModel 盲区过滤 + 仪器偏差、InstitutionModel 权限检查
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createObserverModel,
+  filterObservations,
+  applyInstrumentBias,
+} from '../core/observer-model.js';
+import {
+  createInstitutionModel,
+  checkRolePermission,
+  type InstitutionRule,
+} from '../core/institution-model.js';
+import { ObserverModelStore } from '../core/observer-model-store.js';
+
+// =============================================================================
+// 测试夹具
+// =============================================================================
+
+/** 地面站观察者：有盲区（latent_heat, pump_rpm）和系统偏差 */
+const groundObserver = createObserverModel({
+  id: 'OBS_ground',
+  name: '地面站观察者',
+  description: '地面站传感器，对内部温度有盲区',
+  position: '地面站 A-3 位置',
+  instrumentBiases: [
+    {
+      signalKey: 'temperature',
+      biasKind: 'systematic',
+      magnitude: 2.5,
+      description: '温度传感器系统偏差 +2.5°C',
+    },
+  ],
+  blindZoneSignalKeys: ['latent_heat', 'pump_rpm'],
+});
+
+/** 内部探头观察者：无盲区 */
+const internalProbe = createObserverModel({
+  id: 'OBS_internal',
+  name: '内部探头',
+  description: '直接接触内部组件，无盲区',
+  position: '泵内部探头',
+  blindZoneSignalKeys: [],
+});
+
+/** 制度模型：工厂操作规范 */
+const factoryRules: InstitutionRule[] = [
+  {
+    id: 'RULE_shutdown',
+    description: '紧急关机只允许安全工程师和管理员',
+    constrainedActionKind: 'emergency_shutdown',
+    allowedRoles: ['safety_engineer', 'admin'],
+    forbiddenRoles: [],
+    priority: 10,
+  },
+  {
+    id: 'RULE_read',
+    description: '数据读取所有角色均可',
+    constrainedActionKind: 'read_sensor',
+    allowedRoles: [],
+    forbiddenRoles: [],
+    priority: 5,
+  },
+  {
+    id: 'RULE_no_override',
+    description: '实习生禁止覆写校准参数',
+    constrainedActionKind: 'calibrate',
+    allowedRoles: ['senior_engineer', 'admin'],
+    forbiddenRoles: ['intern'],
+    priority: 8,
+  },
+];
+
+const factory = createInstitutionModel({
+  id: 'IM_factory',
+  name: '工厂操作规范',
+  description: '管理工厂操作权限的制度模型',
+  rules: factoryRules,
+  roleAssignments: [
+    { agentRef: 'agent_alice', role: 'safety_engineer' },
+    { agentRef: 'agent_bob',   role: 'intern' },
+    { agentRef: 'agent_carol', role: 'senior_engineer' },
+  ],
+});
+
+// =============================================================================
+// ObserverModel 工厂
+// =============================================================================
+
+describe('ObserverModel', () => {
+  it('正常创建并校验字段', () => {
+    assert.equal(groundObserver.id, 'OBS_ground');
+    assert.equal(groundObserver.blindZoneSignalKeys.length, 2);
+    assert.equal(groundObserver.instrumentBiases.length, 1);
+    assert.equal(groundObserver.status, 'draft');
+  });
+
+  it('blindZoneSignalKeys 默认为空数组', () => {
+    const obs = createObserverModel({
+      name: 'test',
+      description: '',
+      position: 'remote',
+    });
+    assert.deepEqual(obs.blindZoneSignalKeys, []);
+  });
+
+  it('instrumentBiases 默认为空数组', () => {
+    assert.deepEqual(internalProbe.instrumentBiases, []);
+  });
+});
+
+// =============================================================================
+// filterObservations — 盲区过滤
+// =============================================================================
+
+describe('filterObservations', () => {
+  const signals = {
+    temperature: 85.0,
+    pressure: 3.2,
+    latent_heat: 420.0,
+    pump_rpm: 1500,
+    flow_rate: 12.5,
+  };
+
+  it('地面站观察者：过滤掉 latent_heat 和 pump_rpm', () => {
+    const result = filterObservations(groundObserver, signals);
+    assert.ok(!('latent_heat' in result.filtered));
+    assert.ok(!('pump_rpm' in result.filtered));
+    assert.equal(result.removedKeys.length, 2);
+    assert.ok(result.removedKeys.includes('latent_heat'));
+    assert.ok(result.removedKeys.includes('pump_rpm'));
+  });
+
+  it('地面站观察者：保留非盲区信号', () => {
+    const result = filterObservations(groundObserver, signals);
+    assert.equal(result.filtered.temperature, 85.0);
+    assert.equal(result.filtered.pressure, 3.2);
+    assert.equal(result.filtered.flow_rate, 12.5);
+  });
+
+  it('内部探头：无盲区，所有信号保留', () => {
+    const result = filterObservations(internalProbe, signals);
+    assert.equal(result.removedKeys.length, 0);
+    assert.equal(Object.keys(result.filtered).length, 5);
+  });
+
+  it('filterObservations 是纯函数，不修改原始 signals', () => {
+    const original = { temperature: 100, latent_heat: 500 };
+    filterObservations(groundObserver, original);
+    assert.equal(original.latent_heat, 500);  // 原对象不变
+  });
+
+  it('信号 map 为空时返回空 filtered', () => {
+    const result = filterObservations(groundObserver, {});
+    assert.equal(result.removedKeys.length, 0);
+    assert.deepEqual(result.filtered, {});
+  });
+});
+
+// =============================================================================
+// applyInstrumentBias — 仪器偏差
+// =============================================================================
+
+describe('applyInstrumentBias', () => {
+  it('系统偏差：temperature += 2.5', () => {
+    const signals = { temperature: 80.0, pressure: 3.0 };
+    const result = applyInstrumentBias(groundObserver, signals);
+    assert.equal(result.temperature, 82.5);
+    assert.equal(result.pressure, 3.0);  // 无偏差
+  });
+
+  it('无偏差的观察者：信号不变', () => {
+    const signals = { temperature: 80.0, pump_rpm: 1500 };
+    const result = applyInstrumentBias(internalProbe, signals);
+    assert.deepEqual(result, signals);
+  });
+
+  it('applyInstrumentBias 是纯函数，不修改原始 signals', () => {
+    const original = { temperature: 80.0 };
+    applyInstrumentBias(groundObserver, original);
+    assert.equal(original.temperature, 80.0);  // 原对象不变
+  });
+
+  it('非数值型信号不受偏差影响', () => {
+    const obs = createObserverModel({
+      name: 'str_bias',
+      description: '',
+      position: 'test',
+      instrumentBiases: [{
+        signalKey: 'status',
+        biasKind: 'systematic',
+        magnitude: 1,
+        description: 'test',
+      }],
+    });
+    const signals = { status: 'ok' };
+    const result = applyInstrumentBias(obs, signals);
+    assert.equal(result.status, 'ok');  // 字符串不做数值加法
+  });
+});
+
+// =============================================================================
+// InstitutionModel 工厂 + 权限检查
+// =============================================================================
+
+describe('InstitutionModel', () => {
+  it('正常创建并校验字段', () => {
+    assert.equal(factory.id, 'IM_factory');
+    assert.equal(factory.rules.length, 3);
+    assert.equal(factory.roleAssignments.length, 3);
+  });
+
+  it('不变量 I1：rules 为空时抛出', () => {
+    assert.throws(
+      () => createInstitutionModel({ name: 'empty', description: '', rules: [] }),
+      /不变量 I1/
+    );
+  });
+});
+
+describe('checkRolePermission', () => {
+  it('alice（safety_engineer）可以执行 emergency_shutdown', () => {
+    const result = checkRolePermission(factory, 'agent_alice', 'emergency_shutdown');
+    assert.equal(result.allowed, true);
+    assert.equal(result.matchedRule?.id, 'RULE_shutdown');
+  });
+
+  it('bob（intern）不能执行 emergency_shutdown（不在 allowedRoles）', () => {
+    const result = checkRolePermission(factory, 'agent_bob', 'emergency_shutdown');
+    assert.equal(result.allowed, false);
+  });
+
+  it('所有角色都能执行 read_sensor（allowedRoles 为空）', () => {
+    const resultAlice = checkRolePermission(factory, 'agent_alice', 'read_sensor');
+    const resultBob   = checkRolePermission(factory, 'agent_bob',   'read_sensor');
+    assert.equal(resultAlice.allowed, true);
+    assert.equal(resultBob.allowed,   true);
+  });
+
+  it('bob（intern）被禁止执行 calibrate', () => {
+    const result = checkRolePermission(factory, 'agent_bob', 'calibrate');
+    assert.equal(result.allowed, false);
+    assert.equal(result.matchedRule?.id, 'RULE_no_override');
+  });
+
+  it('carol（senior_engineer）可以执行 calibrate', () => {
+    const result = checkRolePermission(factory, 'agent_carol', 'calibrate');
+    assert.equal(result.allowed, true);
+  });
+
+  it('未知动作类型 → 默认允许（开放世界假设）', () => {
+    const result = checkRolePermission(factory, 'agent_bob', 'unknown_action');
+    assert.equal(result.allowed, true);
+    assert.equal(result.matchedRule, null);
+  });
+
+  it('无角色分配的 Agent → 默认允许 read_sensor', () => {
+    const result = checkRolePermission(factory, 'agent_unknown', 'read_sensor');
+    assert.equal(result.allowed, true);
+  });
+});
+
+// =============================================================================
+// ObserverModelStore 持久化
+// =============================================================================
+
+describe('ObserverModelStore', () => {
+  it('save + get 往返一致', () => {
+    const store = new ObserverModelStore(':memory:');
+    store.save(groundObserver);
+    const retrieved = store.get('OBS_ground');
+    assert.ok(retrieved !== null);
+    assert.equal(retrieved.name, '地面站观察者');
+    assert.equal(retrieved.blindZoneSignalKeys.length, 2);
+    store.close();
+  });
+
+  it('listAll 返回已保存对象', () => {
+    const store = new ObserverModelStore(':memory:');
+    store.save(groundObserver);
+    store.save(internalProbe);
+    const all = store.listAll();
+    assert.equal(all.length, 2);
+    store.close();
+  });
+
+  it('get 不存在 ID 返回 null', () => {
+    const store = new ObserverModelStore(':memory:');
+    assert.equal(store.get('OBS_nonexistent'), null);
+    store.close();
+  });
+});

--- a/docs/current/participatory-world-contract.md
+++ b/docs/current/participatory-world-contract.md
@@ -1,0 +1,78 @@
+# ParticipativeWorld Contract — v10
+
+**状态**: draft  
+**版本**: v10.0  
+**依赖**: v9 ontology-federation-contract, v8 mechanism-program-contract
+
+---
+
+## 1. 动机
+
+v9 引入多本体并存，但仍假设观察者是"透明的"——任何 Agent 都能无偏差地观测一切。v10 引入参与式反射引擎：
+
+- **ObserverModel**：每个观察者有位置、仪器偏差和盲区；其 ObservationRecord 受盲区约束
+- **InstitutionModel**：参与者所处的制度规定哪些动作合法、哪些角色有权执行
+
+---
+
+## 2. 核心对象
+
+### 2.1 ObserverModel
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`OBS_<hex>`） |
+| `position` | string | 观察者位置（物理/角色/层级描述） |
+| `instrumentBiases` | `InstrumentBias[]` | 仪器偏差列表 |
+| `blindZoneSignalKeys` | string[] | 盲区信号 key（**不变量 I1：不可为 null**） |
+| `ontologyId` | string? | 所属本体（v9 联邦） |
+
+**不变量**
+
+- **OBS-I1**: `blindZoneSignalKeys` 不为 null（可为空数组）
+
+**操作**
+
+| 函数 | 说明 |
+|------|------|
+| `filterObservations(observer, signals)` | 从信号 map 中移除盲区 key，返回 FilteredObservation |
+| `applyInstrumentBias(observer, signals)` | 对数值型信号应用 systematic/threshold 偏差 |
+
+### 2.2 InstitutionModel
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`IM_<hex>`） |
+| `rules` | `InstitutionRule[]` | 制度规则（**不变量 I1：至少一条**） |
+| `roleAssignments` | `RoleAssignment[]` | 角色分配（可为空） |
+| `ontologyId` | string? | 所属本体 |
+
+**不变量**
+
+- **IM-I1**: `rules` 非空
+
+**权限检查语义** (`checkRolePermission`)
+
+1. 从 `roleAssignments` 找 agentRef 对应角色
+2. 过滤 `constrainedActionKind === actionKind` 的规则，priority 降序
+3. 遇到 `forbiddenRoles` 命中 → 拒绝
+4. 遇到 `allowedRoles` 命中（或为空） → 允许
+5. 无匹配规则 → 默认允许（开放世界假设）
+
+---
+
+## 3. 存储
+
+| 对象 | Store 类 | 表名 |
+|------|----------|------|
+| ObserverModel | `ObserverModelStore` | `observer_models` |
+| InstitutionModel | 内存（暂无持久化） | — |
+
+---
+
+## 4. 设计决策
+
+- **ObserverModel 影响 ObservationRecord**：`filterObservations` 是纯函数，不修改原信号 map。
+- **InstitutionModel 暂无 store**：制度模型是轻量配置，v10.1 再引入持久化。
+- **开放世界假设**：无匹配制度规则时默认允许，避免过度限制探索阶段的 Agent 行为。
+- **盲区与偏差分离**：盲区（blindZoneSignalKeys）完全过滤信号；偏差（instrumentBiases）修改信号值。两者可叠加使用。


### PR DESCRIPTION
## 实现内容

v10 参与式反射引擎基础对象：观察者模型 + 制度模型。

### 新增文件

| 文件 | 说明 |
|------|------|
| `src/core/observer-model.ts` | ObserverModel + filterObservations + applyInstrumentBias |
| `src/core/observer-model-store.ts` | SQLite 持久化 |
| `src/core/institution-model.ts` | InstitutionModel + checkRolePermission |
| `src/tests/v10-participatory-world.test.ts` | 24 个测试 |
| `docs/current/participatory-world-contract.md` | draft 合约 |

### 关键设计

- `filterObservations`：纯函数，盲区信号完全移除，不修改原 map
- `checkRolePermission`：forbiddenRoles 优先；allowedRoles 空 = 全允；有值不匹配 = 拒绝；无规则 = 开放世界假设

### 测试结果

```
ℹ tests 86
ℹ pass 86
ℹ fail 0
```

Closes #29