### PR TITLE
feat: v11 CivilizationMemory — FailureBoundaryArchive + CounterexampleCommons

### DIFF
--- a/causal-learner/mcp-server/src/core/counterexample-commons.ts
+++ b/causal-learner/mcp-server/src/core/counterexample-commons.ts
@@ -1,0 +1,160 @@
+/**
+ * CounterexampleCommons — v11 反例公共知识库
+ * implements: docs/current/civilization-memory-contract.md
+ *
+ * 存储对已有理论/假设的反驳证据（反例）。
+ * 与 FailureBoundaryArchive 的区别：
+ * - FBA 记录"某件坏事发生了"（经验性失败）
+ * - CounterexampleCommons 记录"某个命题在某条件下为假"（认识论反例）
+ */
+
+import crypto from 'crypto';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 反例严重程度 */
+export type CounterexampleSeverity = 'minor' | 'moderate' | 'critical' | 'fatal';
+
+/** 单条反例条目 */
+export interface CounterexampleEntry {
+  id: string;
+  /** 被反驳的命题/假设 ref（对应 MechanismClass ID、Regulation ID 等） */
+  refutedClaimRef: string;
+  /** 反例描述 */
+  description: string;
+  /** 构成反例的证据 refs（Atom ID、Episode ID 等） */
+  evidenceRefs: string[];
+  /** 触发条件（反例成立的上下文） */
+  triggerContext: string;
+  /** 严重程度 */
+  severity: CounterexampleSeverity;
+  /** 是否已被吸收（理论已更新，反例不再成立） */
+  absorbed: boolean;
+  /** 吸收说明（absorbed=true 时提供） */
+  absorptionNote?: string;
+  createdAt: string;
+  createdBy: string;
+}
+
+/** 反例公共知识库 */
+export interface CounterexampleCommons {
+  id: string;
+  name: string;
+  description: string;
+  /** 反例条目（append-only 语义） */
+  entries: CounterexampleEntry[];
+  createdAt: string;
+  createdBy: string;
+  status: 'draft' | 'current' | 'deprecated';
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateCounterexampleCommonsInput {
+  id?: string;
+  name: string;
+  description: string;
+  entries?: CounterexampleEntry[];
+  createdBy?: string;
+  status?: CounterexampleCommons['status'];
+}
+
+export function createCounterexampleCommons(
+  input: CreateCounterexampleCommonsInput
+): CounterexampleCommons {
+  return {
+    id:          input.id ?? `CC_${crypto.randomBytes(6).toString('hex')}`,
+    name:        input.name,
+    description: input.description,
+    entries:     input.entries ?? [],
+    createdAt:   new Date().toISOString(),
+    createdBy:   input.createdBy ?? 'system',
+    status:      input.status ?? 'draft',
+  };
+}
+
+// =============================================================================
+// 反例操作
+// =============================================================================
+
+export interface AppendCounterexampleInput {
+  refutedClaimRef: string;
+  description: string;
+  evidenceRefs: string[];
+  triggerContext: string;
+  severity: CounterexampleSeverity;
+  createdBy?: string;
+}
+
+/**
+ * 追加反例（immutable update，返回新 CounterexampleCommons）。
+ * 不变量 CE-I1：evidenceRefs 非空。
+ */
+export function appendCounterexample(
+  commons: CounterexampleCommons,
+  input: AppendCounterexampleInput
+): CounterexampleCommons {
+  // 不变量 CE-I1：evidenceRefs 非空
+  if (!input.evidenceRefs || input.evidenceRefs.length === 0) {
+    throw new Error('CounterexampleEntry 不变量 CE-I1：evidenceRefs 不可为空');
+  }
+
+  const entry: CounterexampleEntry = {
+    id:               `CE_${crypto.randomBytes(6).toString('hex')}`,
+    refutedClaimRef:  input.refutedClaimRef,
+    description:      input.description,
+    evidenceRefs:     input.evidenceRefs,
+    triggerContext:   input.triggerContext,
+    severity:         input.severity,
+    absorbed:         false,
+    createdAt:        new Date().toISOString(),
+    createdBy:        input.createdBy ?? 'system',
+  };
+
+  return {
+    ...commons,
+    entries: [...commons.entries, entry],
+  };
+}
+
+/**
+ * 标记反例已被吸收（理论已更新）。
+ */
+export function markCounterexampleAbsorbed(
+  commons: CounterexampleCommons,
+  entryId: string,
+  absorptionNote: string
+): CounterexampleCommons {
+  return {
+    ...commons,
+    entries: commons.entries.map(e =>
+      e.id === entryId ? { ...e, absorbed: true, absorptionNote } : e
+    ),
+  };
+}
+
+/**
+ * 搜索针对特定 claim 的所有未被吸收的反例。
+ */
+export function searchActiveCounterexamples(
+  commons: CounterexampleCommons,
+  claimRef: string
+): CounterexampleEntry[] {
+  return commons.entries.filter(
+    e => e.refutedClaimRef === claimRef && !e.absorbed
+  );
+}
+
+/**
+ * 按严重程度过滤反例。
+ */
+export function searchBySeverity(
+  commons: CounterexampleCommons,
+  severity: CounterexampleSeverity
+): CounterexampleEntry[] {
+  return commons.entries.filter(e => e.severity === severity);
+}

--- a/causal-learner/mcp-server/src/core/failure-boundary-archive-store.ts
+++ b/causal-learner/mcp-server/src/core/failure-boundary-archive-store.ts
@@ -1,0 +1,82 @@
+/**
+ * FailureBoundaryArchiveStore — SQLite 持久化层
+ */
+
+import Database, { Database as DatabaseType } from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { FailureBoundaryArchive } from './failure-boundary-archive.js';
+
+interface ArchiveRow {
+  id: string;
+  name: string;
+  record_count: number;
+  status: string;
+  created_at: string;
+  data: string;
+}
+
+function rowToArchive(row: ArchiveRow): FailureBoundaryArchive {
+  return JSON.parse(row.data) as FailureBoundaryArchive;
+}
+
+export class FailureBoundaryArchiveStore {
+  private db: DatabaseType;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ':memory:') {
+      const dir = path.dirname(dbPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    }
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.initSchema();
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS failure_boundary_archives (
+        id           TEXT PRIMARY KEY,
+        name         TEXT NOT NULL,
+        record_count INTEGER NOT NULL DEFAULT 0,
+        status       TEXT NOT NULL,
+        created_at   TEXT NOT NULL,
+        data         TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_fba_status ON failure_boundary_archives (status);
+    `);
+  }
+
+  save(archive: FailureBoundaryArchive): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO failure_boundary_archives
+        (id, name, record_count, status, created_at, data)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(
+      archive.id,
+      archive.name,
+      archive.records.length,
+      archive.status,
+      archive.createdAt,
+      JSON.stringify(archive)
+    );
+  }
+
+  get(id: string): FailureBoundaryArchive | null {
+    const row = this.db.prepare(
+      'SELECT * FROM failure_boundary_archives WHERE id = ?'
+    ).get(id) as ArchiveRow | undefined;
+    return row ? rowToArchive(row) : null;
+  }
+
+  listAll(limit = 100): FailureBoundaryArchive[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM failure_boundary_archives ORDER BY created_at LIMIT ?'
+    ).all(limit) as ArchiveRow[];
+    return rows.map(rowToArchive);
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/causal-learner/mcp-server/src/core/failure-boundary-archive.ts
+++ b/causal-learner/mcp-server/src/core/failure-boundary-archive.ts
@@ -1,0 +1,204 @@
+/**
+ * FailureBoundaryArchive — v11 失败边界档案
+ * implements: docs/current/civilization-memory-contract.md
+ *
+ * 记录已知的失败案例、失败代价和边界条件。
+ * 语义上 append-only：条目一经写入不可修改，只可追加。
+ * "文明不应重复同一错误"——可查询历史失败的边界条件。
+ */
+
+import crypto from 'crypto';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 失败代价量化 */
+export interface FailureCost {
+  /** 代价类型 */
+  kind: 'resource' | 'time' | 'safety' | 'epistemic' | 'reputational';
+  /** 量化值（可选，具体含义依 kind 而定） */
+  magnitude?: number;
+  /** 单位（可选） */
+  unit?: string;
+  /** 文字说明 */
+  description: string;
+}
+
+/** 边界条件（触发失败的临界值） */
+export interface BoundaryCondition {
+  /** 相关变量/参数 ref */
+  variableRef: string;
+  /** 临界方向 */
+  direction: 'above' | 'below' | 'equal' | 'outside_range';
+  /** 临界值（数值型） */
+  thresholdValue?: number;
+  /** 临界范围 [min, max]（direction=outside_range 时使用） */
+  thresholdRange?: [number, number];
+  /** 说明 */
+  description: string;
+}
+
+/** 失败记录条目（不可变） */
+export interface FailureRecord {
+  id: string;
+  /** 失败发生的 Episode ref */
+  episodeRef: string;
+  /** 触发失败的机制 ref */
+  mechanismRef?: string;
+  /** 失败描述 */
+  description: string;
+  /** 代价列表（不变量 FR-I1：至少一项代价） */
+  costs: FailureCost[];
+  /** 触发此失败的边界条件（不变量 FR-I2：至少一项） */
+  boundaryConditions: BoundaryCondition[];
+  /** 所属本体（v9 联邦上下文，可选） */
+  ontologyId?: string;
+  /** 条目写入时间（不可修改） */
+  recordedAt: string;
+  recordedBy: string;
+}
+
+/** 失败边界档案 */
+export interface FailureBoundaryArchive {
+  id: string;
+  name: string;
+  description: string;
+  /** 失败记录列表（append-only，不变量 FBA-I1：不可 null） */
+  records: FailureRecord[];
+  createdAt: string;
+  createdBy: string;
+  status: 'draft' | 'current' | 'deprecated';
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateFailureBoundaryArchiveInput {
+  id?: string;
+  name: string;
+  description: string;
+  records?: FailureRecord[];
+  createdBy?: string;
+  status?: FailureBoundaryArchive['status'];
+}
+
+export function createFailureBoundaryArchive(
+  input: CreateFailureBoundaryArchiveInput
+): FailureBoundaryArchive {
+  return {
+    id:          input.id ?? `FBA_${crypto.randomBytes(6).toString('hex')}`,
+    name:        input.name,
+    description: input.description,
+    records:     input.records ?? [],
+    createdAt:   new Date().toISOString(),
+    createdBy:   input.createdBy ?? 'system',
+    status:      input.status ?? 'draft',
+  };
+}
+
+// =============================================================================
+// append-only 写入
+// =============================================================================
+
+export interface AppendFailureRecordInput {
+  episodeRef: string;
+  mechanismRef?: string;
+  description: string;
+  costs: FailureCost[];
+  boundaryConditions: BoundaryCondition[];
+  ontologyId?: string;
+  recordedBy?: string;
+}
+
+/**
+ * 向档案追加一条失败记录（immutable update，返回新档案对象）。
+ * 不变量 FR-I1/I2 在此处强制检查。
+ */
+export function appendFailureRecord(
+  archive: FailureBoundaryArchive,
+  input: AppendFailureRecordInput
+): FailureBoundaryArchive {
+  // 不变量 FR-I1：至少一项代价
+  if (!input.costs || input.costs.length === 0) {
+    throw new Error('FailureRecord 不变量 FR-I1：costs 不可为空');
+  }
+  // 不变量 FR-I2：至少一项边界条件
+  if (!input.boundaryConditions || input.boundaryConditions.length === 0) {
+    throw new Error('FailureRecord 不变量 FR-I2：boundaryConditions 不可为空');
+  }
+
+  const record: FailureRecord = {
+    id:                 `FR_${crypto.randomBytes(6).toString('hex')}`,
+    episodeRef:         input.episodeRef,
+    mechanismRef:       input.mechanismRef,
+    description:        input.description,
+    costs:              input.costs,
+    boundaryConditions: input.boundaryConditions,
+    ontologyId:         input.ontologyId,
+    recordedAt:         new Date().toISOString(),
+    recordedBy:         input.recordedBy ?? 'system',
+  };
+
+  return {
+    ...archive,
+    records: [...archive.records, record],
+  };
+}
+
+// =============================================================================
+// 边界查询
+// =============================================================================
+
+/**
+ * 按代价类型过滤失败记录。
+ */
+export function queryRecordsByCostKind(
+  archive: FailureBoundaryArchive,
+  costKind: FailureCost['kind']
+): FailureRecord[] {
+  return archive.records.filter(r =>
+    r.costs.some(c => c.kind === costKind)
+  );
+}
+
+/**
+ * 按边界条件变量 ref 查找相关失败记录。
+ */
+export function queryRecordsByVariable(
+  archive: FailureBoundaryArchive,
+  variableRef: string
+): FailureRecord[] {
+  return archive.records.filter(r =>
+    r.boundaryConditions.some(bc => bc.variableRef === variableRef)
+  );
+}
+
+/**
+ * 检查给定变量值是否触及任一已知边界条件（简单数值型检查）。
+ * 返回所有命中的 FailureRecord。
+ */
+export function checkBoundaryViolation(
+  archive: FailureBoundaryArchive,
+  variableRef: string,
+  currentValue: number
+): FailureRecord[] {
+  return archive.records.filter(r =>
+    r.boundaryConditions.some(bc => {
+      if (bc.variableRef !== variableRef) return false;
+      if (typeof bc.thresholdValue !== 'number') return false;
+      switch (bc.direction) {
+        case 'above':  return currentValue > bc.thresholdValue;
+        case 'below':  return currentValue < bc.thresholdValue;
+        case 'equal':  return currentValue === bc.thresholdValue;
+        case 'outside_range': {
+          if (!bc.thresholdRange) return false;
+          const [min, max] = bc.thresholdRange;
+          return currentValue < min || currentValue > max;
+        }
+        default: return false;
+      }
+    })
+  );
+}

--- a/causal-learner/mcp-server/src/tests/v11-civilization-memory.test.ts
+++ b/causal-learner/mcp-server/src/tests/v11-civilization-memory.test.ts
@@ -1,0 +1,386 @@
+/**
+ * v11 CivilizationMemory 测试
+ * 覆盖：FailureBoundaryArchive append-only + 边界查询、CounterexampleCommons 反例操作
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createFailureBoundaryArchive,
+  appendFailureRecord,
+  queryRecordsByCostKind,
+  queryRecordsByVariable,
+  checkBoundaryViolation,
+  type FailureCost,
+  type BoundaryCondition,
+} from '../core/failure-boundary-archive.js';
+import {
+  createCounterexampleCommons,
+  appendCounterexample,
+  markCounterexampleAbsorbed,
+  searchActiveCounterexamples,
+  searchBySeverity,
+} from '../core/counterexample-commons.js';
+import { FailureBoundaryArchiveStore } from '../core/failure-boundary-archive-store.js';
+
+// =============================================================================
+// 测试夹具
+// =============================================================================
+
+const safetyFailureCost: FailureCost = {
+  kind: 'safety',
+  magnitude: 9.5,
+  unit: 'severity_score',
+  description: '压力超限导致设备损坏',
+};
+
+const timeFailureCost: FailureCost = {
+  kind: 'time',
+  magnitude: 4,
+  unit: 'hours',
+  description: '停机 4 小时修复',
+};
+
+const pressureBoundary: BoundaryCondition = {
+  variableRef: 'pump_pressure',
+  direction: 'above',
+  thresholdValue: 5.0,
+  description: '泵压超过 5.0 MPa 时触发失败',
+};
+
+const tempBoundary: BoundaryCondition = {
+  variableRef: 'temperature',
+  direction: 'outside_range',
+  thresholdValue: 0,
+  thresholdRange: [20, 80],
+  description: '温度超出 20-80°C 正常范围',
+};
+
+// =============================================================================
+// FailureBoundaryArchive 工厂
+// =============================================================================
+
+describe('FailureBoundaryArchive', () => {
+  it('createFailureBoundaryArchive：初始 records 为空', () => {
+    const archive = createFailureBoundaryArchive({
+      name: '泵系统失败档案',
+      description: '记录泵系统历史失败',
+    });
+    assert.equal(archive.records.length, 0);
+    assert.ok(archive.id.startsWith('FBA_'));
+    assert.equal(archive.status, 'draft');
+  });
+});
+
+// =============================================================================
+// appendFailureRecord — append-only 写入
+// =============================================================================
+
+describe('appendFailureRecord', () => {
+  it('追加一条失败记录', () => {
+    let archive = createFailureBoundaryArchive({ name: 'test', description: '' });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_001',
+      description: '泵压超限导致密封件损坏',
+      costs: [safetyFailureCost],
+      boundaryConditions: [pressureBoundary],
+    });
+    assert.equal(archive.records.length, 1);
+    assert.ok(archive.records[0].id.startsWith('FR_'));
+    assert.equal(archive.records[0].episodeRef, 'EP_001');
+  });
+
+  it('多次追加，记录数递增', () => {
+    let archive = createFailureBoundaryArchive({ name: 'test', description: '' });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_001',
+      description: '第一次失败',
+      costs: [safetyFailureCost],
+      boundaryConditions: [pressureBoundary],
+    });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_002',
+      description: '第二次失败',
+      costs: [timeFailureCost],
+      boundaryConditions: [tempBoundary],
+    });
+    assert.equal(archive.records.length, 2);
+  });
+
+  it('append-only：原档案对象不变', () => {
+    const original = createFailureBoundaryArchive({ name: 'test', description: '' });
+    appendFailureRecord(original, {
+      episodeRef: 'EP_001',
+      description: 'test',
+      costs: [safetyFailureCost],
+      boundaryConditions: [pressureBoundary],
+    });
+    assert.equal(original.records.length, 0);  // 原对象不变
+  });
+
+  it('不变量 FR-I1：costs 为空时抛出', () => {
+    const archive = createFailureBoundaryArchive({ name: 'test', description: '' });
+    assert.throws(
+      () => appendFailureRecord(archive, {
+        episodeRef: 'EP_001',
+        description: 'test',
+        costs: [],
+        boundaryConditions: [pressureBoundary],
+      }),
+      /FR-I1/
+    );
+  });
+
+  it('不变量 FR-I2：boundaryConditions 为空时抛出', () => {
+    const archive = createFailureBoundaryArchive({ name: 'test', description: '' });
+    assert.throws(
+      () => appendFailureRecord(archive, {
+        episodeRef: 'EP_001',
+        description: 'test',
+        costs: [safetyFailureCost],
+        boundaryConditions: [],
+      }),
+      /FR-I2/
+    );
+  });
+});
+
+// =============================================================================
+// 边界查询
+// =============================================================================
+
+describe('queryRecordsByCostKind', () => {
+  it('过滤 safety 代价记录', () => {
+    let archive = createFailureBoundaryArchive({ name: 'test', description: '' });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_001',
+      description: '安全失败',
+      costs: [safetyFailureCost],
+      boundaryConditions: [pressureBoundary],
+    });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_002',
+      description: '时间失败',
+      costs: [timeFailureCost],
+      boundaryConditions: [tempBoundary],
+    });
+    const safetyRecords = queryRecordsByCostKind(archive, 'safety');
+    assert.equal(safetyRecords.length, 1);
+    assert.equal(safetyRecords[0].episodeRef, 'EP_001');
+  });
+
+  it('无匹配代价类型 → 返回空数组', () => {
+    let archive = createFailureBoundaryArchive({ name: 'test', description: '' });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_001',
+      description: 'test',
+      costs: [safetyFailureCost],
+      boundaryConditions: [pressureBoundary],
+    });
+    assert.deepEqual(queryRecordsByCostKind(archive, 'epistemic'), []);
+  });
+});
+
+describe('queryRecordsByVariable', () => {
+  it('按变量 ref 过滤边界条件', () => {
+    let archive = createFailureBoundaryArchive({ name: 'test', description: '' });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_001',
+      description: 'pressure failure',
+      costs: [safetyFailureCost],
+      boundaryConditions: [pressureBoundary],
+    });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_002',
+      description: 'temperature failure',
+      costs: [timeFailureCost],
+      boundaryConditions: [tempBoundary],
+    });
+    const pressureRecords = queryRecordsByVariable(archive, 'pump_pressure');
+    assert.equal(pressureRecords.length, 1);
+    assert.equal(pressureRecords[0].episodeRef, 'EP_001');
+  });
+});
+
+describe('checkBoundaryViolation', () => {
+  let archive = createFailureBoundaryArchive({ name: 'test', description: '' });
+  archive = appendFailureRecord(archive, {
+    episodeRef: 'EP_001',
+    description: 'pressure failure',
+    costs: [safetyFailureCost],
+    boundaryConditions: [pressureBoundary],  // above 5.0
+  });
+  archive = appendFailureRecord(archive, {
+    episodeRef: 'EP_002',
+    description: 'temperature failure',
+    costs: [timeFailureCost],
+    boundaryConditions: [tempBoundary],  // outside [20, 80]
+  });
+
+  it('压力 6.0 > 5.0 触发边界违规', () => {
+    const violations = checkBoundaryViolation(archive, 'pump_pressure', 6.0);
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].episodeRef, 'EP_001');
+  });
+
+  it('压力 4.9 < 5.0 不触发违规', () => {
+    const violations = checkBoundaryViolation(archive, 'pump_pressure', 4.9);
+    assert.equal(violations.length, 0);
+  });
+
+  it('温度 15 < 20（outside range）触发违规', () => {
+    const violations = checkBoundaryViolation(archive, 'temperature', 15);
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].episodeRef, 'EP_002');
+  });
+
+  it('温度 50 在范围内不触发违规', () => {
+    const violations = checkBoundaryViolation(archive, 'temperature', 50);
+    assert.equal(violations.length, 0);
+  });
+
+  it('未知变量 → 无违规', () => {
+    const violations = checkBoundaryViolation(archive, 'flow_rate', 999);
+    assert.equal(violations.length, 0);
+  });
+});
+
+// =============================================================================
+// CounterexampleCommons
+// =============================================================================
+
+describe('CounterexampleCommons', () => {
+  it('createCounterexampleCommons：初始 entries 为空', () => {
+    const cc = createCounterexampleCommons({ name: '反例库', description: '' });
+    assert.equal(cc.entries.length, 0);
+    assert.ok(cc.id.startsWith('CC_'));
+  });
+
+  it('appendCounterexample：追加反例', () => {
+    let cc = createCounterexampleCommons({ name: '反例库', description: '' });
+    cc = appendCounterexample(cc, {
+      refutedClaimRef: 'MC_PumpFailure',
+      description: '在低压下泵也出现故障，与 MC_PumpFailure 假设矛盾',
+      evidenceRefs: ['EP_003', 'EP_007'],
+      triggerContext: 'pressure < 1.0 MPa',
+      severity: 'moderate',
+    });
+    assert.equal(cc.entries.length, 1);
+    assert.equal(cc.entries[0].absorbed, false);
+    assert.equal(cc.entries[0].severity, 'moderate');
+  });
+
+  it('不变量 CE-I1：evidenceRefs 为空时抛出', () => {
+    const cc = createCounterexampleCommons({ name: '反例库', description: '' });
+    assert.throws(
+      () => appendCounterexample(cc, {
+        refutedClaimRef: 'MC_test',
+        description: 'test',
+        evidenceRefs: [],
+        triggerContext: 'test',
+        severity: 'minor',
+      }),
+      /CE-I1/
+    );
+  });
+
+  it('appendCounterexample 是 immutable update', () => {
+    const cc = createCounterexampleCommons({ name: '反例库', description: '' });
+    appendCounterexample(cc, {
+      refutedClaimRef: 'MC_x',
+      description: 'test',
+      evidenceRefs: ['EP_001'],
+      triggerContext: 'test',
+      severity: 'minor',
+    });
+    assert.equal(cc.entries.length, 0);  // 原对象不变
+  });
+});
+
+describe('searchActiveCounterexamples', () => {
+  let cc = createCounterexampleCommons({ name: '反例库', description: '' });
+  cc = appendCounterexample(cc, {
+    refutedClaimRef: 'MC_PumpFailure',
+    description: '反例 A',
+    evidenceRefs: ['EP_001'],
+    triggerContext: 'low pressure',
+    severity: 'moderate',
+  });
+  cc = appendCounterexample(cc, {
+    refutedClaimRef: 'MC_PumpFailure',
+    description: '反例 B',
+    evidenceRefs: ['EP_002'],
+    triggerContext: 'high temp',
+    severity: 'critical',
+  });
+  cc = appendCounterexample(cc, {
+    refutedClaimRef: 'MC_HeaterFailure',
+    description: '反例 C',
+    evidenceRefs: ['EP_003'],
+    triggerContext: 'test',
+    severity: 'minor',
+  });
+
+  it('搜索 MC_PumpFailure 的活跃反例', () => {
+    const results = searchActiveCounterexamples(cc, 'MC_PumpFailure');
+    assert.equal(results.length, 2);
+  });
+
+  it('标记吸收后搜索结果减少', () => {
+    const entryId = cc.entries[0].id;
+    const cc2 = markCounterexampleAbsorbed(cc, entryId, '理论已更新为 MC_PumpFailure_v2');
+    const results = searchActiveCounterexamples(cc2, 'MC_PumpFailure');
+    assert.equal(results.length, 1);
+    assert.equal(cc2.entries[0].absorbed, true);
+    assert.equal(cc2.entries[0].absorptionNote, '理论已更新为 MC_PumpFailure_v2');
+  });
+
+  it('按严重程度过滤：critical', () => {
+    const results = searchBySeverity(cc, 'critical');
+    assert.equal(results.length, 1);
+    assert.equal(results[0].description, '反例 B');
+  });
+});
+
+// =============================================================================
+// FailureBoundaryArchiveStore 持久化
+// =============================================================================
+
+describe('FailureBoundaryArchiveStore', () => {
+  it('save + get 往返一致', () => {
+    const store = new FailureBoundaryArchiveStore(':memory:');
+    let archive = createFailureBoundaryArchive({
+      id: 'FBA_test',
+      name: '测试档案',
+      description: '',
+    });
+    archive = appendFailureRecord(archive, {
+      episodeRef: 'EP_001',
+      description: 'test',
+      costs: [safetyFailureCost],
+      boundaryConditions: [pressureBoundary],
+    });
+    store.save(archive);
+    const retrieved = store.get('FBA_test');
+    assert.ok(retrieved !== null);
+    assert.equal(retrieved.records.length, 1);
+    assert.equal(retrieved.records[0].episodeRef, 'EP_001');
+    store.close();
+  });
+
+  it('listAll 返回已保存对象', () => {
+    const store = new FailureBoundaryArchiveStore(':memory:');
+    const a1 = createFailureBoundaryArchive({ id: 'FBA_1', name: 'a1', description: '' });
+    const a2 = createFailureBoundaryArchive({ id: 'FBA_2', name: 'a2', description: '' });
+    store.save(a1);
+    store.save(a2);
+    assert.equal(store.listAll().length, 2);
+    store.close();
+  });
+
+  it('get 不存在 ID 返回 null', () => {
+    const store = new FailureBoundaryArchiveStore(':memory:');
+    assert.equal(store.get('FBA_nonexistent'), null);
+    store.close();
+  });
+});

--- a/docs/current/civilization-memory-contract.md
+++ b/docs/current/civilization-memory-contract.md
@@ -1,0 +1,79 @@
+# CivilizationMemory Contract — v11
+
+**状态**: draft  
+**版本**: v11.0  
+**依赖**: v10 participatory-world-contract, v9 ontology-federation-contract
+
+---
+
+## 1. 动机
+
+v10 引入了观察者和制度，但缺乏对"文明积累的失败知识"的建模。v11 引入文明记忆层：
+
+- **FailureBoundaryArchive**：记录已知失败案例的边界条件，防止同一错误重复发生
+- **CounterexampleCommons**：公共反例知识库，记录对已有理论的反驳证据
+
+两者都是 append-only 的知识结构，体现"求真积累"的文明演化范式。
+
+---
+
+## 2. 核心对象
+
+### 2.1 FailureBoundaryArchive
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`FBA_<hex>`） |
+| `records` | `FailureRecord[]` | 失败记录（**append-only**，不可 null） |
+
+**FailureRecord 不变量**
+
+- **FR-I1**: `costs` 非空（至少一项代价）
+- **FR-I2**: `boundaryConditions` 非空（至少一项边界条件）
+
+**操作**
+
+| 函数 | 说明 |
+|------|------|
+| `appendFailureRecord(archive, input)` | append-only 追加（返回新档案对象） |
+| `queryRecordsByCostKind(archive, kind)` | 按代价类型过滤 |
+| `queryRecordsByVariable(archive, varRef)` | 按边界条件变量过滤 |
+| `checkBoundaryViolation(archive, varRef, value)` | 检查当前值是否触及已知边界 |
+
+### 2.2 CounterexampleCommons
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`CC_<hex>`） |
+| `entries` | `CounterexampleEntry[]` | 反例条目（**append-only**） |
+
+**CounterexampleEntry 不变量**
+
+- **CE-I1**: `evidenceRefs` 非空（至少一条证据）
+
+**操作**
+
+| 函数 | 说明 |
+|------|------|
+| `appendCounterexample(commons, input)` | append-only 追加 |
+| `markCounterexampleAbsorbed(commons, id, note)` | 标记反例已被理论吸收 |
+| `searchActiveCounterexamples(commons, claimRef)` | 搜索未被吸收的反例 |
+| `searchBySeverity(commons, severity)` | 按严重程度过滤 |
+
+---
+
+## 3. 存储
+
+| 对象 | Store 类 | 表名 |
+|------|----------|------|
+| FailureBoundaryArchive | `FailureBoundaryArchiveStore` | `failure_boundary_archives` |
+| CounterexampleCommons | 内存（暂无持久化） | — |
+
+---
+
+## 4. 设计决策
+
+- **Append-only 语义**：失败记录和反例条目一经写入不可修改。`appendFailureRecord` 和 `appendCounterexample` 均返回新对象（immutable update），原档案对象不变。
+- **吸收（absorption）而非删除**：反例被新理论解释后不删除，而是标记 `absorbed: true`，保留知识积累轨迹。
+- **边界违规检查**：`checkBoundaryViolation` 是实时预防工具，当新观测值触及历史失败边界时发出预警。
+- **CounterexampleCommons 暂无持久化**：首轮以内存持有，v11.1 再引入 store。


### PR DESCRIPTION
## 实现内容

v11 文明记忆层基础对象：失败边界档案 + 反例公共知识库。

### 新增文件

| 文件 | 说明 |
|------|------|
| `src/core/failure-boundary-archive.ts` | FBA + append-only + 边界查询 |
| `src/core/failure-boundary-archive-store.ts` | SQLite 持久化 |
| `src/core/counterexample-commons.ts` | CounterexampleCommons + 反例操作 |
| `src/tests/v11-civilization-memory.test.ts` | 24 个测试 |
| `docs/current/civilization-memory-contract.md` | draft 合约 |

### 测试结果

```
ℹ tests 110
ℹ pass 110
ℹ fail 0
```

Closes #31