### PR TITLE
feat: v11 ProofLineage + ConstitutionalLayer

### DIFF
--- a/causal-learner/mcp-server/src/core/constitutional-layer.ts
+++ b/causal-learner/mcp-server/src/core/constitutional-layer.ts
@@ -1,0 +1,267 @@
+/**
+ * ConstitutionalLayer — v11 宪法层（基本求真约束规则集）
+ * implements: docs/current/v11-world-model-contract.md
+ *
+ * ConstitutionalLayer 定义最基本的认识论约束：
+ * 任何声称为"知识"的对象都必须满足这些约束。
+ * 类比法律中的宪法：优先级最高，不可豁免。
+ */
+
+import crypto from 'crypto';
+import type { DerivationTrace } from './types.js';
+import type { ProofLineage } from './proof-lineage.js';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 约束类型 */
+export type ConstraintKind = 'mandatory' | 'aspirational';
+
+/** 约束检查结果 */
+export interface ConstraintCheckResult {
+  constraintId: string;
+  constraintName: string;
+  passed: boolean;
+  kind: ConstraintKind;
+  evidence: string;
+}
+
+/** 单条宪法约束 */
+export interface ConstitutionalConstraint {
+  id: string;
+  name: string;
+  description: string;
+  kind: ConstraintKind;
+  /** 检查函数：接受 DerivationTrace 或 ProofLineage，返回 {passed, evidence} */
+  check: (subject: DerivationTrace | ProofLineage) => { passed: boolean; evidence: string };
+}
+
+/** 宪法层 */
+export interface ConstitutionalLayer {
+  id: string;
+  name: string;
+  description: string;
+  /** 约束规则集（不变量 CL-I1：至少一条） */
+  constraints: ConstitutionalConstraint[];
+  createdAt: string;
+  createdBy: string;
+  status: 'draft' | 'current' | 'deprecated';
+}
+
+/** 完整审计报告 */
+export interface ConstitutionalAudit {
+  subjectId: string;
+  subjectKind: 'DerivationTrace' | 'ProofLineage';
+  results: ConstraintCheckResult[];
+  /** 全部 mandatory 约束是否通过 */
+  mandatoryPassed: boolean;
+  /** 通过的约束数 */
+  passedCount: number;
+  /** 失败的约束数 */
+  failedCount: number;
+  auditedAt: string;
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateConstitutionalLayerInput {
+  id?: string;
+  name: string;
+  description: string;
+  constraints: ConstitutionalConstraint[];
+  createdBy?: string;
+  status?: ConstitutionalLayer['status'];
+}
+
+export function createConstitutionalLayer(
+  input: CreateConstitutionalLayerInput
+): ConstitutionalLayer {
+  // 不变量 CL-I1：constraints 非空
+  if (!input.constraints || input.constraints.length === 0) {
+    throw new Error('ConstitutionalLayer 不变量 CL-I1：constraints 不可为空');
+  }
+
+  return {
+    id:          input.id ?? `CL_${crypto.randomBytes(6).toString('hex')}`,
+    name:        input.name,
+    description: input.description,
+    constraints: input.constraints,
+    createdAt:   new Date().toISOString(),
+    createdBy:   input.createdBy ?? 'system',
+    status:      input.status ?? 'draft',
+  };
+}
+
+// =============================================================================
+// 标准宪法约束集
+// =============================================================================
+
+/**
+ * 内置的基本求真约束规则。
+ * 可直接用于构建 defaultConstitutionalLayer。
+ */
+export const STANDARD_CONSTRAINTS: ConstitutionalConstraint[] = [
+  {
+    id:          'CC_chain_integrity',
+    name:        '推导链完整性',
+    description: 'DerivationTrace 的 chainIntegrity 必须为 complete',
+    kind:        'mandatory',
+    check: (subject) => {
+      if ('chainIntegrity' in subject) {
+        const trace = subject as DerivationTrace;
+        return {
+          passed:   trace.chainIntegrity === 'complete',
+          evidence: `chainIntegrity = "${trace.chainIntegrity}"`,
+        };
+      }
+      // ProofLineage
+      const lineage = subject as ProofLineage;
+      return {
+        passed:   lineage.completeness === 'complete',
+        evidence: `ProofLineage.completeness = "${lineage.completeness}"`,
+      };
+    },
+  },
+  {
+    id:          'CC_has_premises',
+    name:        '前提非空',
+    description: '推导链或证明谱系必须有至少一条前提',
+    kind:        'mandatory',
+    check: (subject) => {
+      if ('premiseClaimIds' in subject && !('nodes' in subject)) {
+        const trace = subject as DerivationTrace;
+        return {
+          passed:   trace.premiseClaimIds.length > 0,
+          evidence: `premiseClaimIds.length = ${trace.premiseClaimIds.length}`,
+        };
+      }
+      const lineage = subject as ProofLineage;
+      return {
+        passed:   lineage.rootPremiseClaimIds.length > 0,
+        evidence: `rootPremiseClaimIds.length = ${lineage.rootPremiseClaimIds.length}`,
+      };
+    },
+  },
+  {
+    id:          'CC_has_conclusion',
+    name:        '结论非空',
+    description: 'DerivationTrace 必须有明确结论 claim ID',
+    kind:        'mandatory',
+    check: (subject) => {
+      if ('conclusionClaimId' in subject && !('nodes' in subject)) {
+        const trace = subject as DerivationTrace;
+        const hasConclusion = !!trace.conclusionClaimId;
+        return {
+          passed:   hasConclusion,
+          evidence: `conclusionClaimId = ${trace.conclusionClaimId ?? 'undefined'}`,
+        };
+      }
+      const lineage = subject as ProofLineage;
+      return {
+        passed:   !!lineage.conclusionClaimId,
+        evidence: `conclusionClaimId = "${lineage.conclusionClaimId}"`,
+      };
+    },
+  },
+  {
+    id:          'CC_replayability',
+    name:        '可重放率 ≥ 50%',
+    description: '推导链的可重放步骤应占总步骤至少 50%（aspirational）',
+    kind:        'aspirational',
+    check: (subject) => {
+      if ('replayableSteps' in subject) {
+        const trace = subject as DerivationTrace;
+        const ratio = trace.totalSteps > 0
+          ? trace.replayableSteps / trace.totalSteps
+          : 1.0;
+        return {
+          passed:   ratio >= 0.5,
+          evidence: `replayableSteps=${trace.replayableSteps} / totalSteps=${trace.totalSteps} = ${ratio.toFixed(2)}`,
+        };
+      }
+      const lineage = subject as ProofLineage;
+      return {
+        passed:   lineage.avgReplayabilityRatio >= 0.5,
+        evidence: `avgReplayabilityRatio = ${lineage.avgReplayabilityRatio.toFixed(2)}`,
+      };
+    },
+  },
+  {
+    id:          'CC_explicit_rejections',
+    name:        '替代假设须显式拒绝',
+    description: '如有支撑链接（supportLinks），则 rejectedClaimIds 不应为空（aspirational）',
+    kind:        'aspirational',
+    check: (subject) => {
+      if ('supportLinks' in subject) {
+        const trace = subject as DerivationTrace;
+        if (trace.supportLinks.length === 0) {
+          // 无支撑链接则此约束不适用
+          return { passed: true, evidence: '无 supportLinks，约束不适用' };
+        }
+        return {
+          passed:   trace.rejectedClaimIds.length > 0,
+          evidence: `supportLinks=${trace.supportLinks.length}, rejectedClaimIds=${trace.rejectedClaimIds.length}`,
+        };
+      }
+      const lineage = subject as ProofLineage;
+      return {
+        passed:   lineage.allRejectedAlternatives.length > 0 || lineage.nodes.every(n => n.rejectedAlternatives.length === 0),
+        evidence: `allRejectedAlternatives.length = ${lineage.allRejectedAlternatives.length}`,
+      };
+    },
+  },
+];
+
+/** 默认宪法层（包含所有标准约束） */
+export function createDefaultConstitutionalLayer(): ConstitutionalLayer {
+  return createConstitutionalLayer({
+    id:          'CL_default',
+    name:        '默认求真宪法层',
+    description: 'v11 基本认识论约束：链路完整性、前提非空、结论非空、可重放率、显式拒绝',
+    constraints: STANDARD_CONSTRAINTS,
+    createdBy:   'system',
+    status:      'current',
+  });
+}
+
+// =============================================================================
+// 审计执行
+// =============================================================================
+
+/**
+ * 对 DerivationTrace 或 ProofLineage 执行宪法审计。
+ * 返回完整 ConstitutionalAudit 报告。
+ */
+export function auditSubject(
+  layer: ConstitutionalLayer,
+  subject: DerivationTrace | ProofLineage,
+  subjectKind: 'DerivationTrace' | 'ProofLineage'
+): ConstitutionalAudit {
+  const results: ConstraintCheckResult[] = layer.constraints.map(constraint => {
+    const { passed, evidence } = constraint.check(subject);
+    return {
+      constraintId:   constraint.id,
+      constraintName: constraint.name,
+      passed,
+      kind:           constraint.kind,
+      evidence,
+    };
+  });
+
+  const mandatoryPassed = results
+    .filter(r => r.kind === 'mandatory')
+    .every(r => r.passed);
+
+  return {
+    subjectId:     subject.id,
+    subjectKind,
+    results,
+    mandatoryPassed,
+    passedCount:   results.filter(r => r.passed).length,
+    failedCount:   results.filter(r => !r.passed).length,
+    auditedAt:     new Date().toISOString(),
+  };
+}

--- a/causal-learner/mcp-server/src/core/proof-lineage.ts
+++ b/causal-learner/mcp-server/src/core/proof-lineage.ts
@@ -1,0 +1,181 @@
+/**
+ * ProofLineage — v11 证明谱系
+ * implements: docs/current/v11-world-model-contract.md
+ *
+ * ProofLineage 从一条或多条 DerivationTrace 链路出发，
+ * 生成完整的从前提到结论的可追溯证明谱系。
+ *
+ * 与 DerivationTrace 的区别：
+ * - DerivationTrace：单次推导过程的记录（步骤 + 支撑链接）
+ * - ProofLineage：多条 DerivationTrace 组合而成的"证明血统"
+ *   — 关注前提→结论的谱系可追溯性，而非单次推导的逐步记录
+ */
+
+import crypto from 'crypto';
+import type { DerivationTrace } from './types.js';
+
+// =============================================================================
+// 类型定义
+// =============================================================================
+
+/** 谱系节点（对应一条 DerivationTrace 的摘要） */
+export interface LineageNode {
+  /** DerivationTrace ID */
+  traceId: string;
+  /** 该 trace 的前提 claim IDs */
+  premiseClaimIds: string[];
+  /** 该 trace 的结论 claim ID */
+  conclusionClaimId: string | undefined;
+  /** 该 trace 的链路完整性 */
+  chainIntegrity: 'complete' | 'broken';
+  /** 该 trace 的可重放率 [0,1] */
+  replayabilityRatio: number;
+  /** 该 trace 中被拒绝的替代假设 */
+  rejectedAlternatives: string[];
+}
+
+/** 证明谱系完整性状态 */
+export type LineageCompleteness = 'complete' | 'partial' | 'broken';
+
+/** 证明谱系 */
+export interface ProofLineage {
+  id: string;
+  name: string;
+  /** 最终结论 claim ID（不变量 PL-I1：非空） */
+  conclusionClaimId: string;
+  /** 所有根前提 claim IDs（从所有 trace 中汇总） */
+  rootPremiseClaimIds: string[];
+  /** 组成谱系的节点列表（按推导顺序，不变量 PL-I2：非空） */
+  nodes: LineageNode[];
+  /** 引用的 DerivationTrace IDs */
+  traceIds: string[];
+  /** 谱系完整性（综合所有节点） */
+  completeness: LineageCompleteness;
+  /** 平均可重放率 */
+  avgReplayabilityRatio: number;
+  /** 被排除的替代假设（所有节点的并集） */
+  allRejectedAlternatives: string[];
+  createdAt: string;
+  createdBy: string;
+}
+
+// =============================================================================
+// 工厂
+// =============================================================================
+
+export interface CreateProofLineageInput {
+  id?: string;
+  name: string;
+  conclusionClaimId: string;
+  nodes: LineageNode[];
+  createdBy?: string;
+}
+
+export function createProofLineage(input: CreateProofLineageInput): ProofLineage {
+  // 不变量 PL-I1：conclusionClaimId 非空
+  if (!input.conclusionClaimId || input.conclusionClaimId.trim() === '') {
+    throw new Error('ProofLineage 不变量 PL-I1：conclusionClaimId 不可为空');
+  }
+  // 不变量 PL-I2：nodes 非空
+  if (!input.nodes || input.nodes.length === 0) {
+    throw new Error('ProofLineage 不变量 PL-I2：nodes 不可为空');
+  }
+
+  // 汇总根前提（所有 node 的 premiseClaimIds 并集，去掉已被某节点作为结论的 ID）
+  const allConclusions = new Set(
+    input.nodes
+      .map(n => n.conclusionClaimId)
+      .filter((id): id is string => id !== undefined)
+  );
+  const rootPremises = Array.from(
+    new Set(
+      input.nodes
+        .flatMap(n => n.premiseClaimIds)
+        .filter(id => !allConclusions.has(id))
+    )
+  );
+
+  // 计算完整性
+  const brokenCount = input.nodes.filter(n => n.chainIntegrity === 'broken').length;
+  let completeness: LineageCompleteness;
+  if (brokenCount === 0) completeness = 'complete';
+  else if (brokenCount === input.nodes.length) completeness = 'broken';
+  else completeness = 'partial';
+
+  // 计算平均可重放率
+  const avgReplayabilityRatio =
+    input.nodes.reduce((sum, n) => sum + n.replayabilityRatio, 0) / input.nodes.length;
+
+  // 汇总所有被拒绝的替代假设
+  const allRejectedAlternatives = Array.from(
+    new Set(input.nodes.flatMap(n => n.rejectedAlternatives))
+  );
+
+  return {
+    id:                       input.id ?? `PL_${crypto.randomBytes(6).toString('hex')}`,
+    name:                     input.name,
+    conclusionClaimId:        input.conclusionClaimId,
+    rootPremiseClaimIds:      rootPremises,
+    nodes:                    input.nodes,
+    traceIds:                 input.nodes.map(n => n.traceId),
+    completeness,
+    avgReplayabilityRatio,
+    allRejectedAlternatives,
+    createdAt:                new Date().toISOString(),
+    createdBy:                input.createdBy ?? 'system',
+  };
+}
+
+// =============================================================================
+// 从 DerivationTrace 反向重建 ProofLineage
+// =============================================================================
+
+/**
+ * 将单条 DerivationTrace 转换为 LineageNode。
+ */
+export function traceToLineageNode(trace: DerivationTrace): LineageNode {
+  const replayabilityRatio =
+    trace.totalSteps > 0
+      ? trace.replayableSteps / trace.totalSteps
+      : 1.0; // 无步骤 = 完全可重放
+
+  return {
+    traceId:              trace.id,
+    premiseClaimIds:      [...trace.premiseClaimIds],
+    conclusionClaimId:    trace.conclusionClaimId,
+    chainIntegrity:       trace.chainIntegrity,
+    replayabilityRatio,
+    rejectedAlternatives: [...trace.rejectedClaimIds],
+  };
+}
+
+/**
+ * 从一条或多条 DerivationTrace 反向重建 ProofLineage。
+ *
+ * @param traces  按推导顺序排列的 DerivationTrace 列表（不变量：非空）
+ * @param name    谱系名称
+ * @param options 附加选项
+ */
+export function buildProofLineage(
+  traces: DerivationTrace[],
+  name: string,
+  options?: { id?: string; createdBy?: string }
+): ProofLineage {
+  if (!traces || traces.length === 0) {
+    throw new Error('buildProofLineage：traces 不可为空');
+  }
+
+  const nodes = traces.map(traceToLineageNode);
+
+  // 最终结论取最后一条 trace 的 conclusionClaimId
+  const lastTrace = traces[traces.length - 1];
+  const conclusionClaimId = lastTrace.conclusionClaimId ?? `UNKNOWN_${lastTrace.id}`;
+
+  return createProofLineage({
+    id:               options?.id,
+    name,
+    conclusionClaimId,
+    nodes,
+    createdBy:        options?.createdBy,
+  });
+}

--- a/causal-learner/mcp-server/src/tests/v11-proof-constitutional.test.ts
+++ b/causal-learner/mcp-server/src/tests/v11-proof-constitutional.test.ts
@@ -1,0 +1,353 @@
+/**
+ * v11 ProofLineage + ConstitutionalLayer 测试
+ * 覆盖：ProofLineage 从 DerivationTrace 反向重建、ConstitutionalLayer 约束审计
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createProofLineage,
+  buildProofLineage,
+  traceToLineageNode,
+} from '../core/proof-lineage.js';
+import {
+  createConstitutionalLayer,
+  createDefaultConstitutionalLayer,
+  auditSubject,
+  STANDARD_CONSTRAINTS,
+} from '../core/constitutional-layer.js';
+import { createDerivationTrace } from '../core/derivation-trace.js';
+import type { DerivationStep, SupportLink } from '../core/types.js';
+
+// =============================================================================
+// 测试夹具
+// =============================================================================
+
+let _stepNum = 0;
+/** 完整的推导步骤（节点连续、可重放） */
+function makeStep(fromId: string, toId: string, replayable = true): DerivationStep {
+  return {
+    stepNumber:      ++_stepNum,
+    from:            { id: fromId, label: fromId, kind: 'claim' },
+    relation:        'causes',
+    to:              { id: toId,   label: toId,   kind: 'claim' },
+    auditReplayable: replayable,
+    llmInvolved:     false,
+  };
+}
+
+/** 构建一条完整 DerivationTrace */
+const completeTrace = createDerivationTrace({
+  id:               'DT_001',
+  episodeId:        'EP_001',
+  contextKind:      'reconstruction',
+  premiseClaimIds:  ['C_premise_A', 'C_premise_B'],
+  conclusionClaimId: 'C_conclusion_1',
+  proof: [
+    makeStep('C_premise_A', 'C_middle_1'),
+    makeStep('C_middle_1', 'C_conclusion_1'),
+  ],
+  supportLinks:     [{
+    id: 'SL_001', observationRecordId: 'OR_001', claimId: 'C_conclusion_1',
+    polarity: 'supports', weight: 0.9, sourceKind: 'pipeline',
+    sourceRef: null, createdAt: new Date().toISOString(), createdBy: 'test',
+  } as SupportLink],
+  rejectedClaimIds: ['C_rejected_alt'],
+  createdBy:        'test',
+});
+
+/** 构建一条不完整的推导链（步骤断裂） */
+const brokenTrace = createDerivationTrace({
+  id:               'DT_002',
+  episodeId:        'EP_002',
+  contextKind:      'inference',
+  premiseClaimIds:  ['C_conclusion_1'],  // 接续前一条 trace 的结论
+  conclusionClaimId: 'C_conclusion_2',
+  proof: [
+    makeStep('C_conclusion_1', 'C_middle_2'),
+    makeStep('C_other',        'C_conclusion_2'),  // 断裂：C_other ≠ C_middle_2
+  ],
+  supportLinks:     [],
+  rejectedClaimIds: [],
+  createdBy:        'test',
+});
+
+/** 构建一条可重放率低的 trace */
+const lowReplayTrace = createDerivationTrace({
+  id:               'DT_003',
+  episodeId:        'EP_003',
+  contextKind:      'inference',
+  premiseClaimIds:  ['C_raw'],
+  conclusionClaimId: 'C_inferred',
+  proof: [
+    makeStep('C_raw', 'C_step1', false),  // 不可重放
+    makeStep('C_step1', 'C_step2', false),  // 不可重放
+    makeStep('C_step2', 'C_inferred', true),  // 可重放
+  ],
+  supportLinks:     [],
+  rejectedClaimIds: [],
+  createdBy:        'test',
+});
+
+// =============================================================================
+// traceToLineageNode
+// =============================================================================
+
+describe('traceToLineageNode', () => {
+  it('完整 trace → 节点完整性 complete', () => {
+    const node = traceToLineageNode(completeTrace);
+    assert.equal(node.traceId, 'DT_001');
+    assert.equal(node.chainIntegrity, 'complete');
+    assert.equal(node.replayabilityRatio, 1.0);
+    assert.deepEqual(node.rejectedAlternatives, ['C_rejected_alt']);
+  });
+
+  it('断裂 trace → 节点完整性 broken', () => {
+    const node = traceToLineageNode(brokenTrace);
+    assert.equal(node.chainIntegrity, 'broken');
+  });
+
+  it('低可重放 trace → replayabilityRatio = 1/3', () => {
+    const node = traceToLineageNode(lowReplayTrace);
+    assert.ok(Math.abs(node.replayabilityRatio - 1 / 3) < 0.01);
+  });
+
+  it('无步骤的 trace → replayabilityRatio = 1.0（默认完全可重放）', () => {
+    const emptyTrace = createDerivationTrace({
+      id: 'DT_empty',
+      premiseClaimIds: ['C_p'],
+      conclusionClaimId: 'C_c',
+    });
+    const node = traceToLineageNode(emptyTrace);
+    assert.equal(node.replayabilityRatio, 1.0);
+  });
+});
+
+// =============================================================================
+// createProofLineage
+// =============================================================================
+
+describe('createProofLineage', () => {
+  it('正常创建并校验字段', () => {
+    const node = traceToLineageNode(completeTrace);
+    const lineage = createProofLineage({
+      name: '测试谱系',
+      conclusionClaimId: 'C_conclusion_1',
+      nodes: [node],
+    });
+    assert.ok(lineage.id.startsWith('PL_'));
+    assert.equal(lineage.conclusionClaimId, 'C_conclusion_1');
+    assert.equal(lineage.completeness, 'complete');
+    assert.equal(lineage.avgReplayabilityRatio, 1.0);
+  });
+
+  it('不变量 PL-I1：conclusionClaimId 为空时抛出', () => {
+    const node = traceToLineageNode(completeTrace);
+    assert.throws(
+      () => createProofLineage({ name: 'test', conclusionClaimId: '', nodes: [node] }),
+      /PL-I1/
+    );
+  });
+
+  it('不变量 PL-I2：nodes 为空时抛出', () => {
+    assert.throws(
+      () => createProofLineage({ name: 'test', conclusionClaimId: 'C_x', nodes: [] }),
+      /PL-I2/
+    );
+  });
+
+  it('混合完整+断裂节点 → completeness = partial', () => {
+    const lineage = createProofLineage({
+      name: 'partial',
+      conclusionClaimId: 'C_conclusion_2',
+      nodes: [traceToLineageNode(completeTrace), traceToLineageNode(brokenTrace)],
+    });
+    assert.equal(lineage.completeness, 'partial');
+  });
+
+  it('全断裂节点 → completeness = broken', () => {
+    const lineage = createProofLineage({
+      name: 'broken',
+      conclusionClaimId: 'C_conclusion_2',
+      nodes: [traceToLineageNode(brokenTrace)],
+    });
+    assert.equal(lineage.completeness, 'broken');
+  });
+
+  it('rootPremiseClaimIds 正确排除中间节点', () => {
+    // completeTrace: premises=[A, B] → conclusion=C_conclusion_1
+    // brokenTrace:   premises=[C_conclusion_1] → conclusion=C_conclusion_2
+    // 链接后根前提应为 [A, B]，C_conclusion_1 不应出现（它是中间结论）
+    const lineage = createProofLineage({
+      name: 'chained',
+      conclusionClaimId: 'C_conclusion_2',
+      nodes: [traceToLineageNode(completeTrace), traceToLineageNode(brokenTrace)],
+    });
+    assert.ok(lineage.rootPremiseClaimIds.includes('C_premise_A'));
+    assert.ok(lineage.rootPremiseClaimIds.includes('C_premise_B'));
+    assert.ok(!lineage.rootPremiseClaimIds.includes('C_conclusion_1'));
+  });
+
+  it('allRejectedAlternatives 汇总各节点的拒绝列表', () => {
+    const lineage = createProofLineage({
+      name: 'test',
+      conclusionClaimId: 'C_conclusion_2',
+      nodes: [traceToLineageNode(completeTrace), traceToLineageNode(brokenTrace)],
+    });
+    assert.ok(lineage.allRejectedAlternatives.includes('C_rejected_alt'));
+  });
+});
+
+// =============================================================================
+// buildProofLineage — 从 DerivationTrace 反向重建
+// =============================================================================
+
+describe('buildProofLineage', () => {
+  it('单条 complete trace → lineage complete', () => {
+    const lineage = buildProofLineage([completeTrace], '单 trace 谱系');
+    assert.equal(lineage.completeness, 'complete');
+    assert.equal(lineage.conclusionClaimId, 'C_conclusion_1');
+    assert.equal(lineage.traceIds.length, 1);
+  });
+
+  it('多条 trace 链 → 最后一条的结论作为最终结论', () => {
+    const lineage = buildProofLineage(
+      [completeTrace, brokenTrace],
+      '两条 trace 谱系'
+    );
+    assert.equal(lineage.conclusionClaimId, 'C_conclusion_2');
+    assert.equal(lineage.traceIds.length, 2);
+  });
+
+  it('空 traces 数组时抛出', () => {
+    assert.throws(
+      () => buildProofLineage([], '空谱系'),
+      /traces 不可为空/
+    );
+  });
+});
+
+// =============================================================================
+// ConstitutionalLayer 工厂
+// =============================================================================
+
+describe('ConstitutionalLayer', () => {
+  it('createConstitutionalLayer 正常创建', () => {
+    const layer = createConstitutionalLayer({
+      name: '测试宪法层',
+      description: '',
+      constraints: [STANDARD_CONSTRAINTS[0]],
+    });
+    assert.ok(layer.id.startsWith('CL_'));
+    assert.equal(layer.constraints.length, 1);
+  });
+
+  it('不变量 CL-I1：constraints 为空时抛出', () => {
+    assert.throws(
+      () => createConstitutionalLayer({ name: 'empty', description: '', constraints: [] }),
+      /CL-I1/
+    );
+  });
+
+  it('createDefaultConstitutionalLayer 包含 5 条标准约束', () => {
+    const layer = createDefaultConstitutionalLayer();
+    assert.equal(layer.constraints.length, 5);
+    assert.equal(layer.status, 'current');
+  });
+});
+
+// =============================================================================
+// auditSubject — 对 DerivationTrace 审计
+// =============================================================================
+
+describe('auditSubject (DerivationTrace)', () => {
+  const layer = createDefaultConstitutionalLayer();
+
+  it('完整 trace 通过所有 mandatory 约束', () => {
+    const audit = auditSubject(layer, completeTrace, 'DerivationTrace');
+    assert.equal(audit.mandatoryPassed, true);
+    assert.equal(audit.subjectId, 'DT_001');
+  });
+
+  it('完整 trace 通过可重放率约束（2/2 = 100%）', () => {
+    const audit = auditSubject(layer, completeTrace, 'DerivationTrace');
+    const replayResult = audit.results.find(r => r.constraintId === 'CC_replayability');
+    assert.ok(replayResult?.passed);
+  });
+
+  it('低可重放 trace chainIntegrity=broken → mandatory CC_chain_integrity 失败', () => {
+    // lowReplayTrace 有非可重放步骤 → chainIntegrity=broken → mandatory 失败
+    const audit = auditSubject(layer, lowReplayTrace, 'DerivationTrace');
+    const chainResult = audit.results.find(r => r.constraintId === 'CC_chain_integrity');
+    assert.equal(chainResult?.passed, false);  // chain integrity fails
+    const replayResult = audit.results.find(r => r.constraintId === 'CC_replayability');
+    assert.equal(replayResult?.passed, false);  // aspirational also fails
+  });
+
+  it('断裂 trace mandatory 失败', () => {
+    const audit = auditSubject(layer, brokenTrace, 'DerivationTrace');
+    const chainResult = audit.results.find(r => r.constraintId === 'CC_chain_integrity');
+    assert.equal(chainResult?.passed, false);
+    assert.equal(audit.mandatoryPassed, false);
+  });
+
+  it('无结论的 trace CC_has_conclusion 失败', () => {
+    const noConclusionTrace = createDerivationTrace({
+      id: 'DT_no_conclusion',
+      premiseClaimIds: ['C_p'],
+      // conclusionClaimId 未设置
+    });
+    const audit = auditSubject(layer, noConclusionTrace, 'DerivationTrace');
+    const conclusionResult = audit.results.find(r => r.constraintId === 'CC_has_conclusion');
+    assert.equal(conclusionResult?.passed, false);
+  });
+});
+
+// =============================================================================
+// auditSubject — 对 ProofLineage 审计
+// =============================================================================
+
+describe('auditSubject (ProofLineage)', () => {
+  const layer = createDefaultConstitutionalLayer();
+
+  it('完整谱系通过所有 mandatory 约束', () => {
+    const lineage = buildProofLineage([completeTrace], 'test');
+    const audit = auditSubject(layer, lineage, 'ProofLineage');
+    assert.equal(audit.mandatoryPassed, true);
+    assert.equal(audit.subjectKind, 'ProofLineage');
+  });
+
+  it('断裂谱系 CC_chain_integrity mandatory 失败', () => {
+    const lineage = buildProofLineage([brokenTrace], 'broken');
+    const audit = auditSubject(layer, lineage, 'ProofLineage');
+    const chainResult = audit.results.find(r => r.constraintId === 'CC_chain_integrity');
+    assert.equal(chainResult?.passed, false);
+    assert.equal(audit.mandatoryPassed, false);
+  });
+
+  it('passedCount + failedCount = constraints 总数', () => {
+    const lineage = buildProofLineage([completeTrace], 'test');
+    const audit = auditSubject(layer, lineage, 'ProofLineage');
+    assert.equal(audit.passedCount + audit.failedCount, layer.constraints.length);
+  });
+
+  it('低可重放率谱系：aspirational 失败但 mandatory 通过', () => {
+    // 手动构造一个 completeness=complete 但 avgReplayabilityRatio=0.3 的谱系
+    const lineage = createProofLineage({
+      name: 'low replayability lineage',
+      conclusionClaimId: 'C_conclusion_low',
+      nodes: [{
+        traceId:              'DT_low',
+        premiseClaimIds:      ['C_p'],
+        conclusionClaimId:    'C_conclusion_low',
+        chainIntegrity:       'complete',  // 链路完整
+        replayabilityRatio:   0.3,         // 但可重放率低
+        rejectedAlternatives: [],
+      }],
+    });
+    const audit = auditSubject(layer, lineage, 'ProofLineage');
+    assert.equal(audit.mandatoryPassed, true);  // 所有 mandatory 均通过
+    const replayResult = audit.results.find(r => r.constraintId === 'CC_replayability');
+    assert.equal(replayResult?.passed, false);  // aspirational 失败
+  });
+});

--- a/docs/current/v11-world-model-contract.md
+++ b/docs/current/v11-world-model-contract.md
@@ -1,0 +1,101 @@
+# v11 World Model Contract — ReflexiveCivilizationEngine
+
+**状态**: draft  
+**版本**: v11.0  
+**依赖**: v10 participatory-world-contract, civilization-memory-contract
+
+---
+
+## 1. v11 愿景
+
+v11 是 BestQ-A 世界模型的最高抽象层：**反射性文明引擎**。
+
+核心哲学：文明通过积累失败经验（v11 CivilizationMemory）和构建可追溯的求真证明体系（v11 ProofLineage + ConstitutionalLayer），实现自我反射和认识论演化。
+
+---
+
+## 2. 核心对象
+
+### 2.1 ProofLineage（证明谱系）
+
+ProofLineage 将一条或多条 DerivationTrace 组合为"证明血统"，关注从前提到结论的谱系可追溯性。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`PL_<hex>`） |
+| `conclusionClaimId` | string | 最终结论（**不变量 PL-I1：非空**） |
+| `rootPremiseClaimIds` | string[] | 汇总根前提 |
+| `nodes` | `LineageNode[]` | 谱系节点（**不变量 PL-I2：非空**） |
+| `completeness` | enum | `complete` / `partial` / `broken` |
+| `avgReplayabilityRatio` | number | 平均可重放率 [0,1] |
+| `allRejectedAlternatives` | string[] | 所有节点排除的替代假设并集 |
+
+**不变量**
+
+- **PL-I1**: `conclusionClaimId` 非空
+- **PL-I2**: `nodes` 非空
+
+**反向重建**
+
+`buildProofLineage(traces, name)` — 从有序 DerivationTrace 列表反向重建 ProofLineage：
+1. 每条 trace → `traceToLineageNode(trace)` 生成 LineageNode
+2. 汇总所有节点的根前提（已被某节点作为结论的 claim ID 从根前提中排除）
+3. 最后一条 trace 的 `conclusionClaimId` 作为 ProofLineage 的最终结论
+4. 综合所有节点的 `chainIntegrity` 计算 `completeness`
+
+### 2.2 ConstitutionalLayer（宪法层）
+
+ConstitutionalLayer 定义最基本的认识论约束：任何"知识"对象都必须满足 mandatory 约束。
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 全局唯一（`CL_<hex>`） |
+| `constraints` | `ConstitutionalConstraint[]` | 约束规则（**不变量 CL-I1：至少一条**） |
+
+**不变量**
+
+- **CL-I1**: `constraints` 非空
+
+**标准约束集**（`STANDARD_CONSTRAINTS`）
+
+| 约束 ID | 名称 | 类型 | 说明 |
+|---------|------|------|------|
+| `CC_chain_integrity` | 推导链完整性 | mandatory | chainIntegrity === 'complete' |
+| `CC_has_premises` | 前提非空 | mandatory | premiseClaimIds.length > 0 |
+| `CC_has_conclusion` | 结论非空 | mandatory | conclusionClaimId 非空 |
+| `CC_replayability` | 可重放率 ≥ 50% | aspirational | replayableSteps/totalSteps >= 0.5 |
+| `CC_explicit_rejections` | 替代假设须显式拒绝 | aspirational | 有 supportLinks 时须有 rejectedClaimIds |
+
+**审计执行**
+
+`auditSubject(layer, subject, kind)` → `ConstitutionalAudit`：
+- 对每条约束调用 `constraint.check(subject)`
+- `mandatoryPassed`: 所有 mandatory 约束均通过
+- `passedCount / failedCount`: 通过/失败数量
+
+---
+
+## 3. v8-v11 对象全景
+
+| 层 | 对象 | 核心功能 |
+|----|------|---------|
+| v8 | MechanismProgram | phase 执行 + 反事实推演 |
+| v8 | ExperimentDesign | 信息增益计算 |
+| v9 | OntologyModel | 多本体并存 |
+| v9 | TranslationFunctor | 跨本体翻译 |
+| v9 | ConflictSet | 本体冲突收集 |
+| v10 | ObserverModel | 观察者盲区 + 偏差 |
+| v10 | InstitutionModel | 制度约束 + 权限检查 |
+| v11 | FailureBoundaryArchive | 历史失败边界 |
+| v11 | CounterexampleCommons | 反例公共知识库 |
+| v11 | ProofLineage | 证明谱系重建 |
+| v11 | ConstitutionalLayer | 基本求真约束审计 |
+
+---
+
+## 4. 设计决策
+
+- **ProofLineage vs DerivationTrace**：DerivationTrace 是单次推导的原始记录；ProofLineage 是"血统视图"，关注前提-结论的可追溯性，可跨多条 trace 组合。
+- **ConstitutionalLayer 约束分两级**：mandatory（必须满足）和 aspirational（期望满足）。合规检查只以 mandatory 为准。
+- **默认宪法层**：`createDefaultConstitutionalLayer()` 提供开箱即用的标准约束集，可作为所有 DerivationTrace 和 ProofLineage 的基线审计层。
+- **约束函数是纯函数**：`ConstitutionalConstraint.check` 不修改 subject，返回 `{passed, evidence}` 元组。


### PR DESCRIPTION
## 实现内容

v11 证明谱系 + 宪法约束审计层。

### 新增文件

| 文件 | 说明 |
|------|------|
| `src/core/proof-lineage.ts` | ProofLineage + traceToLineageNode + buildProofLineage |
| `src/core/constitutional-layer.ts` | ConstitutionalLayer + 5 条标准约束 + auditSubject |
| `src/tests/v11-proof-constitutional.test.ts` | 26 个测试 |
| `docs/current/v11-world-model-contract.md` | draft 合约 + v8-v11 对象全景 |

### 测试结果

```
ℹ tests 136
ℹ pass 136
ℹ fail 0
```

Closes #33