### PR TITLE
P08 v11 全链路 contract-audit 覆盖：§24 checkV9V10V11Coverage + 四合约 YAML frontmatter

### DIFF
--- a/artifacts/contract-audit-latest.json
+++ b/artifacts/contract-audit-latest.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-04-14T12:14:39.636Z",
-  "files_scanned": 707,
+  "timestamp": "2026-04-15T10:17:04.649Z",
+  "files_scanned": 711,
   "errors": [
     {
       "file": "docs/current/reporting-workflow-contract.md",
@@ -82,11 +82,25 @@
       "msg": "describes 与 docs/current/transition-contract.md 相似（Jaccard=0.60）"
     },
     {
+      "file": "docs/current/civilization-memory-contract.md",
+      "line": 1,
+      "code": "describes-too-long",
+      "level": "warning",
+      "msg": "describes 超过 20 字：54 字"
+    },
+    {
       "file": "docs/current/intent-alignment-audit-contract.md",
       "line": 1,
       "code": "describes-too-long",
       "level": "warning",
       "msg": "describes 超过 20 字：27 字"
+    },
+    {
+      "file": "docs/current/ontology-federation-contract.md",
+      "line": 1,
+      "code": "describes-too-long",
+      "level": "warning",
+      "msg": "describes 超过 20 字：55 字"
     },
     {
       "file": "docs/current/outcome-record-contract.md",
@@ -122,6 +136,13 @@
       "code": "duplicate-truth",
       "level": "warning",
       "msg": "describes 与 docs/current/transition-contract.md 相似（Jaccard=0.60）"
+    },
+    {
+      "file": "docs/current/participatory-world-contract.md",
+      "line": 1,
+      "code": "describes-too-long",
+      "level": "warning",
+      "msg": "describes 超过 20 字：42 字"
     },
     {
       "file": "docs/current/prediction-error-contract.md",
@@ -178,6 +199,13 @@
       "code": "describes-too-long",
       "level": "warning",
       "msg": "describes 超过 20 字：32 字"
+    },
+    {
+      "file": "docs/current/review-decision-contract.md",
+      "line": 107,
+      "code": "symbol-drift",
+      "msg": "符号 `rejectProposal` 在附近引用的 .ts 文件中未找到",
+      "level": "warning"
     },
     {
       "file": "docs/current/state-snapshot-contract.md",
@@ -257,6 +285,13 @@
       "msg": "describes 与 docs/current/state-snapshot-contract.md 相似（Jaccard=0.60）"
     },
     {
+      "file": "docs/current/v11-world-model-contract.md",
+      "line": 1,
+      "code": "describes-too-long",
+      "level": "warning",
+      "msg": "describes 超过 20 字：44 字"
+    },
+    {
       "file": "docs/current/validity-envelope-contract.md",
       "line": 1,
       "code": "describes-too-long",
@@ -266,11 +301,11 @@
   ],
   "summary": {
     "ok": 693,
-    "warn": 10,
+    "warn": 14,
     "err": 4
   },
   "kind_distribution": {
-    "contract": 48,
+    "contract": 52,
     "instance": 641,
     "record": 2,
     "code": 12,
@@ -344,7 +379,19 @@
     "bad_rd_proposal_ref": [],
     "bad_rd_decision": [],
     "bad_rd_superseded_ref": [],
-    "empty_rd_rationale": []
+    "empty_rd_rationale": [],
+    "bad_ve_mechanism_program_ref": [],
+    "empty_ve_conditions": [],
+    "bad_ve_confidence_band": [],
+    "orphan_current_validity_envelope": [],
+    "missing_v9_contract": [],
+    "missing_v10_contract": [],
+    "missing_v11_civilization_contract": [],
+    "missing_v11_reflexive_contract": [],
+    "missing_v9_impl": [],
+    "missing_v10_impl": [],
+    "missing_v11_civilization_impl": [],
+    "missing_v11_reflexive_impl": []
   },
   "density_distribution": [
     {
@@ -363,6 +410,11 @@
       "density": 0.069
     },
     {
+      "file": "docs/current/civilization-memory-contract.md",
+      "kind": "contract",
+      "density": 0
+    },
+    {
       "file": "docs/current/compile-promotion-contract.md",
       "kind": "contract",
       "density": 0
@@ -370,7 +422,7 @@
     {
       "file": "docs/current/contract-audit-contract.md",
       "kind": "contract",
-      "density": 0.0129
+      "density": 0.0124
     },
     {
       "file": "docs/current/contract-vs-impl-audit.md",
@@ -488,7 +540,17 @@
       "density": 0.0431
     },
     {
+      "file": "docs/current/ontology-federation-contract.md",
+      "kind": "contract",
+      "density": 0
+    },
+    {
       "file": "docs/current/outcome-record-contract.md",
+      "kind": "contract",
+      "density": 0
+    },
+    {
+      "file": "docs/current/participatory-world-contract.md",
       "kind": "contract",
       "density": 0
     },
@@ -579,6 +641,11 @@
     },
     {
       "file": "docs/current/transition-contract.md",
+      "kind": "contract",
+      "density": 0
+    },
+    {
+      "file": "docs/current/v11-world-model-contract.md",
       "kind": "contract",
       "density": 0
     },
@@ -7839,6 +7906,17 @@
       "warnings": 0
     },
     {
+      "file": "docs/current/civilization-memory-contract.md",
+      "format": "md",
+      "status": "draft",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "FailureBoundaryArchive / CounterexampleCommons 文明记忆层规范",
+      "density": 0,
+      "errors": 0,
+      "warnings": 1
+    },
+    {
       "file": "docs/current/compile-promotion-contract.md",
       "format": "md",
       "status": "current",
@@ -7856,7 +7934,7 @@
       "kind": "contract",
       "legacy_kind": null,
       "describes": "契约审计规则规格",
-      "density": 0.0129,
+      "density": 0.0124,
       "errors": 0,
       "warnings": 0
     },
@@ -8114,6 +8192,17 @@
       "warnings": 0
     },
     {
+      "file": "docs/current/ontology-federation-contract.md",
+      "format": "md",
+      "status": "draft",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "OntologyModel / TranslationFunctor / ConflictSet 本体联邦规范",
+      "density": 0,
+      "errors": 0,
+      "warnings": 1
+    },
+    {
       "file": "docs/current/outcome-record-contract.md",
       "format": "md",
       "status": "current",
@@ -8123,6 +8212,17 @@
       "density": 0,
       "errors": 0,
       "warnings": 5
+    },
+    {
+      "file": "docs/current/participatory-world-contract.md",
+      "format": "md",
+      "status": "draft",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "ObserverModel / InstitutionModel 参与式自反世界规范",
+      "density": 0,
+      "errors": 0,
+      "warnings": 1
     },
     {
       "file": "docs/current/pipeline-contract.md",
@@ -8204,13 +8304,13 @@
     {
       "file": "docs/current/review-decision-contract.md",
       "format": "md",
-      "status": "draft",
+      "status": "current",
       "kind": "contract",
       "legacy_kind": null,
       "describes": "ProgramRevisionProposal 审查决策对象规范",
       "density": 0,
       "errors": 0,
-      "warnings": 1
+      "warnings": 2
     },
     {
       "file": "docs/current/run-summary-contract.md",
@@ -8321,6 +8421,17 @@
       "density": 0,
       "errors": 0,
       "warnings": 5
+    },
+    {
+      "file": "docs/current/v11-world-model-contract.md",
+      "format": "md",
+      "status": "draft",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "ProofLineage / ConstitutionalLayer 反射性文明引擎规范",
+      "density": 0,
+      "errors": 0,
+      "warnings": 1
     },
     {
       "file": "docs/current/v6-world-model-contract.md",

--- a/docs/current/civilization-memory-contract.md
+++ b/docs/current/civilization-memory-contract.md
@@ -1,3 +1,16 @@
+---
+kind: contract
+status: draft
+phase: 10
+schema_version: 1
+describes: "FailureBoundaryArchive / CounterexampleCommons 文明记忆层规范"
+upstream:
+  - participatory-world-contract.md
+  - ontology-federation-contract.md
+downstream:
+  - v11-world-model-contract.md
+---
+
 # CivilizationMemory Contract — v11
 
 **状态**: draft  

--- a/docs/current/ontology-federation-contract.md
+++ b/docs/current/ontology-federation-contract.md
@@ -1,3 +1,16 @@
+---
+kind: contract
+status: draft
+phase: 7
+schema_version: 1
+describes: "OntologyModel / TranslationFunctor / ConflictSet 本体联邦规范"
+upstream:
+  - v7-world-model-contract.md
+  - mechanism-program-contract.md
+downstream:
+  - participatory-world-contract.md
+---
+
 # OntologyFederation Contract — v9
 
 **状态**: draft  

--- a/docs/current/participatory-world-contract.md
+++ b/docs/current/participatory-world-contract.md
@@ -1,3 +1,16 @@
+---
+kind: contract
+status: draft
+phase: 9
+schema_version: 1
+describes: "ObserverModel / InstitutionModel 参与式自反世界规范"
+upstream:
+  - ontology-federation-contract.md
+  - mechanism-program-contract.md
+downstream:
+  - civilization-memory-contract.md
+---
+
 # ParticipativeWorld Contract — v10
 
 **状态**: draft  

--- a/docs/current/v11-world-model-contract.md
+++ b/docs/current/v11-world-model-contract.md
@@ -1,3 +1,15 @@
+---
+kind: contract
+status: draft
+phase: 11
+schema_version: 1
+describes: "ProofLineage / ConstitutionalLayer 反射性文明引擎规范"
+upstream:
+  - civilization-memory-contract.md
+  - participatory-world-contract.md
+downstream: []
+---
+
 # v11 World Model Contract — ReflexiveCivilizationEngine
 
 **状态**: draft  

--- a/scripts/contract-audit.mjs
+++ b/scripts/contract-audit.mjs
@@ -1581,6 +1581,74 @@ async function checkValidityEnvelopeBindings(results) {
   }
 }
 
+/** §24 v9/v10/v11 本体联邦 + 参与式世界 + 文明记忆 + 反射性文明引擎 覆盖率 binding pass
+ *
+ * 验证 v9-v11 对象有合约文件（kind=contract）+ TypeScript 实现绑定。
+ * 错误码：
+ *   missing-v9-contract              — ontology-federation-contract.md 缺失或非 contract 类型
+ *   missing-v10-contract             — participatory-world-contract.md 缺失或非 contract 类型
+ *   missing-v11-civilization-contract — civilization-memory-contract.md 缺失或非 contract 类型
+ *   missing-v11-reflexive-contract   — v11-world-model-contract.md 缺失或非 contract 类型
+ *   missing-v9-impl                  — v9 TypeScript 实现文件不存在
+ *   missing-v10-impl                 — v10 TypeScript 实现文件不存在
+ *   missing-v11-civilization-impl    — v11 文明记忆 TypeScript 实现文件不存在
+ *   missing-v11-reflexive-impl       — v11 ProofLineage/ConstitutionalLayer 实现文件不存在
+ */
+async function checkV9V10V11Coverage(results) {
+  const CONTRACTS = [
+    { file: 'docs/current/ontology-federation-contract.md',  code: 'missing-v9-contract',               label: 'v9 OntologyFederation' },
+    { file: 'docs/current/participatory-world-contract.md',  code: 'missing-v10-contract',              label: 'v10 ParticipativeWorld' },
+    { file: 'docs/current/civilization-memory-contract.md',  code: 'missing-v11-civilization-contract', label: 'v11 CivilizationMemory' },
+    { file: 'docs/current/v11-world-model-contract.md',      code: 'missing-v11-reflexive-contract',    label: 'v11 ReflexiveCivilizationEngine' },
+  ];
+
+  const IMPLS = [
+    { rel: 'causal-learner/mcp-server/src/core/ontology-model.ts',           code: 'missing-v9-impl',               label: 'v9 OntologyModel' },
+    { rel: 'causal-learner/mcp-server/src/core/translation-functor.ts',      code: 'missing-v9-impl',               label: 'v9 TranslationFunctor' },
+    { rel: 'causal-learner/mcp-server/src/core/conflict-set.ts',             code: 'missing-v9-impl',               label: 'v9 ConflictSet' },
+    { rel: 'causal-learner/mcp-server/src/core/observer-model.ts',           code: 'missing-v10-impl',              label: 'v10 ObserverModel' },
+    { rel: 'causal-learner/mcp-server/src/core/institution-model.ts',        code: 'missing-v10-impl',              label: 'v10 InstitutionModel' },
+    { rel: 'causal-learner/mcp-server/src/core/failure-boundary-archive.ts', code: 'missing-v11-civilization-impl', label: 'v11 FailureBoundaryArchive' },
+    { rel: 'causal-learner/mcp-server/src/core/counterexample-commons.ts',   code: 'missing-v11-civilization-impl', label: 'v11 CounterexampleCommons' },
+    { rel: 'causal-learner/mcp-server/src/core/proof-lineage.ts',            code: 'missing-v11-reflexive-impl',    label: 'v11 ProofLineage' },
+    { rel: 'causal-learner/mcp-server/src/core/constitutional-layer.ts',     code: 'missing-v11-reflexive-impl',    label: 'v11 ConstitutionalLayer' },
+  ];
+
+  const byFile = new Map(results.map(r => [r.file, r]));
+
+  // 合约文件检查：必须存在且 kind=contract
+  for (const { file, code, label } of CONTRACTS) {
+    const r = byFile.get(file);
+    if (!r || r.kind !== 'contract') {
+      const target = r ?? byFile.get('scripts/contract-audit.mjs');
+      if (target) {
+        target.findings.push({ file: target.file, line: 1, code, level: 'error',
+          msg: `${label} 合约文件缺失或 kind 非 contract：${file}` });
+      }
+    }
+  }
+
+  // TypeScript 实现文件检查
+  const implContractMap = {
+    'missing-v9-impl':               'docs/current/ontology-federation-contract.md',
+    'missing-v10-impl':              'docs/current/participatory-world-contract.md',
+    'missing-v11-civilization-impl': 'docs/current/civilization-memory-contract.md',
+    'missing-v11-reflexive-impl':    'docs/current/v11-world-model-contract.md',
+  };
+  for (const { rel, code, label } of IMPLS) {
+    const abs = path.join(ROOT, ...rel.split('/'));
+    const info = await readFileInfo(abs);
+    if (!info.exists) {
+      const contractFile = implContractMap[code];
+      const r = byFile.get(contractFile) ?? byFile.get('scripts/contract-audit.mjs');
+      if (r) {
+        r.findings.push({ file: r.file, line: 1, code, level: 'error',
+          msg: `${label} TypeScript 实现文件不存在：${rel}` });
+      }
+    }
+  }
+}
+
 async function main() {
   const targets = await collectTargets();
   const results = [];
@@ -1607,6 +1675,7 @@ async function main() {
   await checkSupportLinkDeepBindings(results);
   await checkReviewDecisionBindings(results);
   await checkValidityEnvelopeBindings(results);
+  await checkV9V10V11Coverage(results);
 
   // kind 分布
   const kindDist = { contract: 0, instance: 0, record: 0, code: 0, index: 0, legacy_I: 0, legacy_II: 0, missing: 0 };
@@ -1694,6 +1763,15 @@ async function main() {
     empty_ve_conditions: [],
     bad_ve_confidence_band: [],
     orphan_current_validity_envelope: [],
+    // v9/v10/v11 覆盖率 pass（§24）
+    missing_v9_contract: [],
+    missing_v10_contract: [],
+    missing_v11_civilization_contract: [],
+    missing_v11_reflexive_contract: [],
+    missing_v9_impl: [],
+    missing_v10_impl: [],
+    missing_v11_civilization_impl: [],
+    missing_v11_reflexive_impl: [],
   };
   const codeToBucket = {
     'missing-conforms-to': 'missing_conforms_to',
@@ -1774,6 +1852,20 @@ async function main() {
     'bad-rd-decision':        'bad_rd_decision',
     'bad-rd-superseded-ref':  'bad_rd_superseded_ref',
     'empty-rd-rationale':     'empty_rd_rationale',
+    // ValidityEnvelope binding pass（§23）
+    'bad-ve-mechanism-program-ref':        'bad_ve_mechanism_program_ref',
+    'empty-ve-conditions':                 'empty_ve_conditions',
+    'bad-ve-confidence-band':              'bad_ve_confidence_band',
+    'orphan-current-validity-envelope':    'orphan_current_validity_envelope',
+    // v9/v10/v11 覆盖率 pass（§24）
+    'missing-v9-contract':               'missing_v9_contract',
+    'missing-v10-contract':              'missing_v10_contract',
+    'missing-v11-civilization-contract': 'missing_v11_civilization_contract',
+    'missing-v11-reflexive-contract':    'missing_v11_reflexive_contract',
+    'missing-v9-impl':                   'missing_v9_impl',
+    'missing-v10-impl':                  'missing_v10_impl',
+    'missing-v11-civilization-impl':     'missing_v11_civilization_impl',
+    'missing-v11-reflexive-impl':        'missing_v11_reflexive_impl',
   };
   for (const r of results) {
     for (const f of r.findings) {
@@ -1852,7 +1944,7 @@ async function main() {
   process.exit(errors.length > 0 ? 1 : 0);
 }
 
-export { checkV7Bindings, checkObservationModelBindings, checkCounterfactualBindings, checkExperimentDesignBindings, checkActionExecutionBindings, checkOutcomeRecordBindings, checkPredictionErrorBindings, checkStateSnapshotBindings, checkTransitionBindings, checkMechanismClassBindings, checkProgramRevisionProposalBindings, checkSupportLinkDeepBindings, checkReviewDecisionBindings };
+export { checkV7Bindings, checkObservationModelBindings, checkCounterfactualBindings, checkExperimentDesignBindings, checkActionExecutionBindings, checkOutcomeRecordBindings, checkPredictionErrorBindings, checkStateSnapshotBindings, checkTransitionBindings, checkMechanismClassBindings, checkProgramRevisionProposalBindings, checkSupportLinkDeepBindings, checkReviewDecisionBindings, checkValidityEnvelopeBindings, checkV9V10V11Coverage };
 
 const _IS_MAIN = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(__filename);
 if (_IS_MAIN) {


### PR DESCRIPTION
## Summary

- 为 v9/v10/v11 四个合约文件（ontology-federation、participatory-world、civilization-memory、v11-world-model）添加 YAML frontmatter（`kind: contract`、`status: draft`、`upstream`/`downstream`）
- `scripts/contract-audit.mjs` 新增 §24 `checkV9V10V11Coverage`：验证 9 个 TypeScript 实现文件 + 4 个合约文件均存在并绑定
- 将 VE（§23）和新 §24 错误码注册到 `bindingErrors` + `codeToBucket`
- `checkV9V10V11Coverage` 加入 export 列表

## Test plan

- [x] `node scripts/contract-audit.mjs` 运行无新增错误（4 个新合约 ✅/⚠️，residual 6 错误均为预存问题）
- [x] `npm test` 136 pass / 0 fail
- [x] `scripts/contract-audit.mjs` 自身 ✅（kind=code，0 errors）

Closes #35

🤖 Generated with [Claude Code](https://claude.ai/claude-code)