### PR TITLE
fix(mcp): 归纳引擎 contextKeys 动态提取

### DIFF
--- a/causal-learner/mcp-server/src/tools/induction.ts
+++ b/causal-learner/mcp-server/src/tools/induction.ts
@@ -381,9 +381,20 @@ export function triggerInductionTool(
     };
   }
 
+  // 从聚类事件的实际 context 动态提取共同 keys，不再硬编码 SWE-bench 字段
+  const allContextKeys = new Set<string>();
+  for (const cluster of eventClusters) {
+    for (const evt of cluster) {
+      if (evt.context) {
+        for (const k of Object.keys(evt.context)) {
+          allContextKeys.add(k);
+        }
+      }
+    }
+  }
   const coreOptions = {
     minEvents: minClusterSize,
-    contextKeys: ['repo', 'error.type', 'test.framework', 'env.os'],
+    contextKeys: [...allContextKeys],
   };
 
   // Induce regulations from each cluster


### PR DESCRIPTION
## Summary

- `triggerInductionTool` 的 `contextKeys` 从硬编码 SWE-bench 字段改为从聚类事件的实际 context 动态提取
- 修复 regulation `pre=[]` 的问题——现在归纳引擎能从 context 中提取共同前提条件

## 根因

`contextKeys: ['repo', 'error.type', 'test.framework', 'env.os']` 硬编码，brew coffee 观测的 context 用 `program`/`hasPower`/`calciumBlocked`，完全不匹配 → `factsFromContext()` 返回空 → regulation pre=[]

## Test plan

- [x] 147 tests pass, 0 fail
- [x] `tsc` 编译零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)