### PR TITLE
feat: docs/current 合约 + BranchPoint v13 schema + PresentSlice

### DIFF
--- a/causal-learner/mcp-server/src/core/branch-point.ts
+++ b/causal-learner/mcp-server/src/core/branch-point.ts
@@ -18,6 +18,8 @@ export interface BranchPoint {
   id: string;
   /** 所属 Episode（lineage 锚点） */
   episodeId: string;
+  /** v13: 血统链 ID，追踪分叉的历史谱系 */
+  lineageId?: string;
   /** 分叉位置描述（人类可读） */
   locationDescription: string;
   /** 候选路径数量（= FutureBranch 数量） */
@@ -26,6 +28,8 @@ export interface BranchPoint {
   controllableFactors: string[];
   /** 不可控因素（来自 context 中不可干预的 keys） */
   uncontrollableFactors: string[];
+  /** v13: 历史敏感性标签，标记哪些历史因素对此分叉有决定性影响 */
+  historicalSensitivity?: string[];
   /** 最终选定的 FutureBranch ID */
   chosenBranchId: string | null;
   /** 创建时间 */
@@ -35,10 +39,12 @@ export interface BranchPoint {
 
 export interface CreateBranchPointInput {
   episodeId: string;
+  lineageId?: string;
   locationDescription: string;
   candidateCount: number;
   controllableFactors?: string[];
   uncontrollableFactors?: string[];
+  historicalSensitivity?: string[];
   createdBy?: string;
 }
 
@@ -46,10 +52,12 @@ export function createBranchPoint(input: CreateBranchPointInput): BranchPoint {
   return {
     id: `BP_${crypto.randomBytes(6).toString('hex')}`,
     episodeId: input.episodeId,
+    lineageId: input.lineageId,
     locationDescription: input.locationDescription,
     candidateCount: input.candidateCount,
     controllableFactors: input.controllableFactors ?? [],
     uncontrollableFactors: input.uncontrollableFactors ?? [],
+    historicalSensitivity: input.historicalSensitivity,
     chosenBranchId: null,
     createdAt: new Date().toISOString(),
     createdBy: input.createdBy ?? 'system',
@@ -69,10 +77,18 @@ export interface FutureBranch {
   branchPointId: string;
   /** 路径 Atom ID 列表 */
   pathAtomIds: string[];
-  /** 预测结果描述 */
+  /** v13: 关联的干预 ID 列表，标记此分支依赖哪些主动干预 */
+  interventionIds?: string[];
+  /** v13: 预测轨迹，按时序描述路径上的关键状态变化 */
+  predictedTrajectory?: string[];
+  /** 预测结果描述（兼容旧 string 单值） */
   predictedOutcome: string;
-  /** 风险描述 */
-  riskProfile: string;
+  /** v13: 预测结果列表，多维度结果预测 */
+  predictedOutcomes?: string[];
+  /** 风险描述（v13 扩展为 string | string[]，兼容数组形式） */
+  riskProfile: string | string[];
+  /** v13: 信息增益估计，量化此分支对认知的贡献度 */
+  informationGainEstimate?: number;
   /** 路径权重/得分 */
   score: number;
   /** 分支状态 */
@@ -85,8 +101,12 @@ export interface FutureBranch {
 export interface CreateFutureBranchInput {
   branchPointId: string;
   pathAtomIds: string[];
+  interventionIds?: string[];
+  predictedTrajectory?: string[];
   predictedOutcome?: string;
-  riskProfile?: string;
+  predictedOutcomes?: string[];
+  riskProfile?: string | string[];
+  informationGainEstimate?: number;
   score: number;
   status?: BranchStatus;
   pruneReason?: string;
@@ -97,8 +117,12 @@ export function createFutureBranch(input: CreateFutureBranchInput): FutureBranch
     id: `FB_${crypto.randomBytes(6).toString('hex')}`,
     branchPointId: input.branchPointId,
     pathAtomIds: input.pathAtomIds,
+    interventionIds: input.interventionIds,
+    predictedTrajectory: input.predictedTrajectory,
     predictedOutcome: input.predictedOutcome ?? '',
+    predictedOutcomes: input.predictedOutcomes,
     riskProfile: input.riskProfile ?? '',
+    informationGainEstimate: input.informationGainEstimate,
     score: input.score,
     status: input.status ?? 'pending',
     pruneReason: input.pruneReason,

--- a/causal-learner/mcp-server/src/core/index.ts
+++ b/causal-learner/mcp-server/src/core/index.ts
@@ -904,3 +904,26 @@ export {
   STANDARD_CONSTRAINTS,
   auditSubject,
 } from './constitutional-layer.js';
+
+// =============================================================================
+// v13 PresentSlice（当前观测面 — lineage-centered 桥接对象）
+// =============================================================================
+
+export type {
+  PresentSlice,
+  CreatePresentSliceInput,
+  PipelineSnapshot,
+} from './present-slice.js';
+
+export {
+  createPresentSlice,
+  buildPresentSliceFromPipeline,
+} from './present-slice.js';
+
+export type {
+  PresentSliceStoreStats,
+} from './present-slice-store.js';
+
+export {
+  PresentSliceStore,
+} from './present-slice-store.js';

--- a/causal-learner/mcp-server/src/core/present-slice-store.ts
+++ b/causal-learner/mcp-server/src/core/present-slice-store.ts
@@ -1,0 +1,107 @@
+/**
+ * PresentSliceStore — PresentSlice SQLite 持久化层
+ *
+ * 遵循 ReconstructionStore / BranchPointStore 的统一模式：
+ * - better-sqlite3 WAL 模式
+ * - data 列存完整 JSON
+ * - 索引列用于高频查询
+ */
+
+import Database, { Database as DatabaseType } from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import type { PresentSlice } from './present-slice.js';
+
+export interface PresentSliceStoreStats {
+  totalCount: number;
+}
+
+export class PresentSliceStore {
+  private db: DatabaseType;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ':memory:') {
+      const dir = path.dirname(dbPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    }
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.initSchema();
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS present_slices (
+        id              TEXT PRIMARY KEY,
+        name            TEXT NOT NULL,
+        fidelity_score  REAL NOT NULL,
+        created_at      TEXT NOT NULL,
+        created_by      TEXT NOT NULL,
+        data            TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_ps_fidelity ON present_slices (fidelity_score);
+      CREATE INDEX IF NOT EXISTS idx_ps_created_at ON present_slices (created_at);
+    `);
+  }
+
+  /** 保存（INSERT OR REPLACE） */
+  save(slice: PresentSlice): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO present_slices
+        (id, name, fidelity_score, created_at, created_by, data)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(
+      slice.id,
+      slice.name,
+      slice.fidelityScore,
+      slice.createdAt,
+      slice.createdBy,
+      JSON.stringify(slice),
+    );
+  }
+
+  /** 按 ID 查询 */
+  get(id: string): PresentSlice | null {
+    const row = this.db.prepare(
+      'SELECT data FROM present_slices WHERE id = ?'
+    ).get(id) as { data: string } | undefined;
+    return row ? JSON.parse(row.data) : null;
+  }
+
+  /** 查询所有 slice（按创建时间降序） */
+  listAll(limit = 100): PresentSlice[] {
+    const rows = this.db.prepare(
+      'SELECT data FROM present_slices ORDER BY created_at DESC LIMIT ?'
+    ).all(limit) as { data: string }[];
+    return rows.map(r => JSON.parse(r.data));
+  }
+
+  /** 查询 fidelity 低于阈值的 slice（用于审计） */
+  getLowFidelity(threshold: number, limit = 50): PresentSlice[] {
+    const rows = this.db.prepare(
+      'SELECT data FROM present_slices WHERE fidelity_score < ? ORDER BY fidelity_score ASC LIMIT ?'
+    ).all(threshold, limit) as { data: string }[];
+    return rows.map(r => JSON.parse(r.data));
+  }
+
+  /** 按 Episode ID 查询包含该 episode 的 slice（JSON 子串匹配） */
+  getByEpisodeId(episodeId: string): PresentSlice[] {
+    // SQLite JSON 子串搜索：episodeIds 数组序列化后包含该 ID
+    const rows = this.db.prepare(
+      "SELECT data FROM present_slices WHERE data LIKE ? ORDER BY created_at DESC"
+    ).all(`%"${episodeId}"%`) as { data: string }[];
+    // 二次过滤确保精确匹配
+    return rows
+      .map(r => JSON.parse(r.data) as PresentSlice)
+      .filter(s => s.episodeIds.includes(episodeId));
+  }
+
+  getStats(): PresentSliceStoreStats {
+    const row = this.db.prepare('SELECT COUNT(*) as cnt FROM present_slices').get() as { cnt: number };
+    return { totalCount: row.cnt };
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/causal-learner/mcp-server/src/core/present-slice.ts
+++ b/causal-learner/mcp-server/src/core/present-slice.ts
@@ -1,0 +1,177 @@
+/**
+ * PresentSlice — v13 当前观测面的显式对象化
+ * implements: docs/design_history/v13_historical_generative_ontology.md §7.1
+ *
+ * PresentSlice 不是整个 Episode，而是：
+ * - 在当前时刻真正需要解释的状态压缩面
+ * - 之后一切 provenance tracing 的起点
+ * - 压缩了历史 Episode 的 lineage，声明"这个当下是什么"
+ *
+ * 语义中心：从"五模块并列"走向"lineage-centered"的桥接对象。
+ * 本文件只建对象和工厂函数，不接入 pipeline.ts。
+ */
+
+import crypto from 'crypto';
+
+// =============================================================================
+// PresentSlice 接口
+// =============================================================================
+
+/** 当前观测面 — v13 核心桥接对象 */
+export interface PresentSlice {
+  /** 唯一标识 */
+  id: string;
+  /** 人类可读名称（描述这个当下切片的含义） */
+  name: string;
+  /** 构成此 slice 的 Episode ID 列表（历史来源） */
+  episodeIds: string[];
+  /** 来源重建 ID 列表（provenance 指向 AcceptedReconstruction） */
+  reconstructionIds: string[];
+  /** 当前活跃的因果规律 ID 列表（从 Regulation/MechanismClass 提取） */
+  activeRegulationIds: string[];
+  /** 当前活跃的分叉点 ID 列表（从 BranchPoint 提取） */
+  activeBranchPointIds: string[];
+  /** 压缩说明 — 人类可读，描述从 Episode lineage 压缩到当前态的过程 */
+  compressionSummary: string;
+  /** 综合保真度 [0.0, 1.0] — 聚合各 Reconstruction 的 fidelity */
+  fidelityScore: number;
+  /** 状态快照 ID 列表（v13 §7.1 stateSnapshotIds） */
+  stateSnapshotIds: string[];
+  /** 当前活跃约束（v13 §7.1 activeConstraints） */
+  activeConstraints: string[];
+  /** 可见结果（v13 §7.1 visibleOutcomes） */
+  visibleOutcomes: string[];
+  /** 推断的潜在状态（v13 §7.1 inferredLatentStates） */
+  inferredLatentStates: string[];
+  /** 未解决的未知项（v13 §7.1 unresolvedUnknowns） */
+  unresolvedUnknowns: string[];
+  /** 创建时间 */
+  createdAt: string;
+  /** 创建者标识 */
+  createdBy: string;
+}
+
+// =============================================================================
+// 创建输入
+// =============================================================================
+
+export interface CreatePresentSliceInput {
+  name: string;
+  episodeIds: string[];
+  reconstructionIds?: string[];
+  activeRegulationIds?: string[];
+  activeBranchPointIds?: string[];
+  compressionSummary?: string;
+  fidelityScore?: number;
+  stateSnapshotIds?: string[];
+  activeConstraints?: string[];
+  visibleOutcomes?: string[];
+  inferredLatentStates?: string[];
+  unresolvedUnknowns?: string[];
+  createdBy?: string;
+  createdAt?: string;
+}
+
+// =============================================================================
+// 工厂函数
+// =============================================================================
+
+function clamp01(v: number): number {
+  if (!Number.isFinite(v)) return 0;
+  return Math.max(0, Math.min(1, v));
+}
+
+/** 创建 PresentSlice 实例 */
+export function createPresentSlice(input: CreatePresentSliceInput): PresentSlice {
+  return {
+    id: `PS_${crypto.randomBytes(6).toString('hex')}`,
+    name: input.name,
+    episodeIds: input.episodeIds,
+    reconstructionIds: input.reconstructionIds ?? [],
+    activeRegulationIds: input.activeRegulationIds ?? [],
+    activeBranchPointIds: input.activeBranchPointIds ?? [],
+    compressionSummary: input.compressionSummary ?? '',
+    fidelityScore: clamp01(input.fidelityScore ?? 0),
+    stateSnapshotIds: input.stateSnapshotIds ?? [],
+    activeConstraints: input.activeConstraints ?? [],
+    visibleOutcomes: input.visibleOutcomes ?? [],
+    inferredLatentStates: input.inferredLatentStates ?? [],
+    unresolvedUnknowns: input.unresolvedUnknowns ?? [],
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    createdBy: input.createdBy ?? 'system',
+  };
+}
+
+// =============================================================================
+// Pipeline 构建器（从 CausalPipeline 实例提取当前态）
+// =============================================================================
+
+/**
+ * buildPresentSliceFromPipeline 的输入 — 从 pipeline 各 store 中提取的快照数据。
+ *
+ * 设计选择：不直接依赖 CausalPipeline 类型（避免循环依赖），
+ * 而是接受一个扁平的数据快照，由调用方从 pipeline 实例中提取。
+ */
+export interface PipelineSnapshot {
+  /** slice 名称 */
+  name: string;
+  /** Episode ID 列表 */
+  episodeIds: string[];
+  /** AcceptedReconstruction ID 列表 */
+  reconstructionIds: string[];
+  /** 各 Reconstruction 的 fidelity score */
+  reconstructionFidelities: number[];
+  /** 当前活跃的 Regulation / MechanismClass ID 列表 */
+  activeRegulationIds: string[];
+  /** 当前活跃的 BranchPoint ID 列表 */
+  activeBranchPointIds: string[];
+  /** StateSnapshot ID 列表 */
+  stateSnapshotIds?: string[];
+  /** 活跃约束 */
+  activeConstraints?: string[];
+  /** 可见结果 */
+  visibleOutcomes?: string[];
+  /** 推断的潜在状态 */
+  inferredLatentStates?: string[];
+  /** 未解决的未知项 */
+  unresolvedUnknowns?: string[];
+  /** 创建者标识 */
+  createdBy?: string;
+}
+
+/**
+ * 从 pipeline 快照构建 PresentSlice。
+ *
+ * fidelityScore 取所有 Reconstruction fidelity 的加权平均（等权），
+ * 若无 Reconstruction 则为 0。
+ * compressionSummary 自动生成，描述压缩来源。
+ */
+export function buildPresentSliceFromPipeline(snapshot: PipelineSnapshot): PresentSlice {
+  const fidelities = snapshot.reconstructionFidelities;
+  const avgFidelity = fidelities.length > 0
+    ? fidelities.reduce((sum, f) => sum + f, 0) / fidelities.length
+    : 0;
+
+  const compressionSummary = [
+    `压缩自 ${snapshot.episodeIds.length} 个 Episode`,
+    `${snapshot.reconstructionIds.length} 个 Reconstruction`,
+    `${snapshot.activeRegulationIds.length} 条活跃规律`,
+    `${snapshot.activeBranchPointIds.length} 个分叉点`,
+  ].join('，');
+
+  return createPresentSlice({
+    name: snapshot.name,
+    episodeIds: snapshot.episodeIds,
+    reconstructionIds: snapshot.reconstructionIds,
+    activeRegulationIds: snapshot.activeRegulationIds,
+    activeBranchPointIds: snapshot.activeBranchPointIds,
+    compressionSummary,
+    fidelityScore: avgFidelity,
+    stateSnapshotIds: snapshot.stateSnapshotIds,
+    activeConstraints: snapshot.activeConstraints,
+    visibleOutcomes: snapshot.visibleOutcomes,
+    inferredLatentStates: snapshot.inferredLatentStates,
+    unresolvedUnknowns: snapshot.unresolvedUnknowns,
+    createdBy: snapshot.createdBy ?? 'pipeline',
+  });
+}

--- a/docs/current/branch-point-contract.md
+++ b/docs/current/branch-point-contract.md
@@ -1,0 +1,202 @@
+---
+kind: contract
+status: current
+implements:
+  - causal-learner/mcp-server/src/core/branch-point.ts
+  - causal-learner/mcp-server/src/core/branch-point-store.ts
+---
+
+# BranchPoint 合同：因果链分叉治理
+
+> 定义 BranchPoint + FutureBranch 的职责、接口、状态机、持久化层。
+> 上游依赖：v13 §8.1-8.2（历史生成本体论 — 分叉治理）
+> 关联实现：`core/branch-point.ts`、`core/branch-point-store.ts`
+
+---
+
+## §1 定义与边界
+
+**BranchPoint** 标记因果链上的分叉位置：系统在此处面临多条候选路径，必须选择一条执行、剪除其余。
+
+**FutureBranch** 描述 BranchPoint 下的每条候选路径：预测结果、风险、得分、状态。
+
+**语义来源**：从 pipeline 的 `candidatePaths` / `chosenPath` / `failedPaths` 自然派生。每次 `recordFix` 产生多条候选时，pipeline 创建一个 BranchPoint + N 个 FutureBranch，选择得分最高者，剪除其余。
+
+---
+
+## §2 BranchPoint Schema
+
+```yaml
+BranchPoint:
+  id: string                       # 格式: "BP_<random_hex_12>"
+  episodeId: string                # 所属 Episode（lineage 锚点）
+  locationDescription: string      # 分叉位置描述（人类可读）
+  candidateCount: number           # 候选路径数量（= FutureBranch 数量）
+  controllableFactors: string[]    # 可控因素（来自 context 中可干预的 keys）
+  uncontrollableFactors: string[]  # 不可控因素
+  chosenBranchId: string | null    # 最终选定的 FutureBranch ID
+  createdAt: ISO8601
+  createdBy: string                # "system" | 具体调用方标识
+```
+
+---
+
+## §3 FutureBranch Schema
+
+```yaml
+FutureBranch:
+  id: string                       # 格式: "FB_<random_hex_12>"
+  branchPointId: string            # 所属 BranchPoint
+  pathAtomIds: string[]            # 路径 Atom ID 列表
+  predictedOutcome: string         # 预测结果描述
+  riskProfile: string              # 风险描述
+  score: number                    # 路径权重/得分
+  status: BranchStatus             # 见 §4
+  pruneReason?: string             # status=pruned 时的剪除原因
+  createdAt: ISO8601
+```
+
+---
+
+## §4 状态机
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending : createFutureBranch()
+  pending --> chosen : chooseBranch(branchId)
+  pending --> pruned : chooseBranch(otherId)
+```
+
+| 状态 | 语义 | 转入条件 |
+|------|------|---------|
+| `pending` | 候选未决 | 创建时默认状态 |
+| `chosen` | 选中执行 | `chooseBranch` 指定该分支 |
+| `pruned` | 剪除 | `chooseBranch` 指定其他分支后自动标记 |
+
+**`chooseBranch` 语义**：接受一个 `chosenBranchId`，将该分支标为 `chosen`，将同 BranchPoint 下所有 `pending` 分支标为 `pruned`（附 `pruneReason`），同时更新 `BranchPoint.chosenBranchId`。
+
+状态转换是**单向终态**：`chosen` 和 `pruned` 不可回退。
+
+---
+
+## §5 工厂函数
+
+| 函数 | 签名 | 语义 |
+|------|------|------|
+| `createBranchPoint` | `(input: CreateBranchPointInput) => BranchPoint` | 生成 BranchPoint，`chosenBranchId` 初始为 null |
+| `createFutureBranch` | `(input: CreateFutureBranchInput) => FutureBranch` | 生成 FutureBranch，默认 `status=pending` |
+| `chooseBranch` | `(bp, branches, chosenBranchId, pruneReason?) => { branchPoint, branches }` | 执行选择 + 剪除，返回更新后的不可变副本 |
+
+---
+
+## §6 BranchPointStore 持久化层
+
+SQLite（better-sqlite3）持久化层，WAL 模式。
+
+### §6.1 存储 Schema
+
+```sql
+CREATE TABLE branch_points (
+  id               TEXT PRIMARY KEY,
+  episode_id       TEXT NOT NULL,
+  candidate_count  INTEGER NOT NULL,
+  chosen_branch_id TEXT,
+  created_at       TEXT NOT NULL,
+  data             TEXT NOT NULL          -- 完整 BranchPoint JSON
+);
+CREATE INDEX idx_bp_episode ON branch_points (episode_id);
+
+CREATE TABLE future_branches (
+  id               TEXT PRIMARY KEY,
+  branch_point_id  TEXT NOT NULL,
+  status           TEXT NOT NULL,
+  score            REAL NOT NULL,
+  created_at       TEXT NOT NULL,
+  data             TEXT NOT NULL,          -- 完整 FutureBranch JSON
+  FOREIGN KEY (branch_point_id) REFERENCES branch_points(id)
+);
+CREATE INDEX idx_fb_bp     ON future_branches (branch_point_id);
+CREATE INDEX idx_fb_status ON future_branches (status);
+```
+
+### §6.2 接口
+
+| 方法 | 签名 | 语义 |
+|------|------|------|
+| `saveBranchPoint` | `(bp: BranchPoint) => void` | INSERT OR REPLACE |
+| `saveFutureBranch` | `(fb: FutureBranch) => void` | INSERT OR REPLACE |
+| `getBranchPoint` | `(id: string) => BranchPoint \| null` | 按主键查询 |
+| `getByEpisode` | `(episodeId: string) => BranchPoint[]` | 按 Episode 查询（created_at 升序） |
+| `getBranches` | `(branchPointId: string) => FutureBranch[]` | 按 BranchPoint 查询所有分支（score 降序） |
+| `getPrunedBranches` | `(limit?: number) => FutureBranch[]` | 查询所有被剪除的分支（用于失败边界审计），默认 limit=50 |
+| `getStats` | `() => BranchPointStoreStats` | 返回 `{ branchPointCount, futureBranchCount }` |
+| `close` | `() => void` | 关闭数据库连接 |
+
+### §6.3 BranchPointStoreStats
+
+```typescript
+interface BranchPointStoreStats {
+  branchPointCount: number;
+  futureBranchCount: number;
+}
+```
+
+---
+
+## §7 不变量
+
+| # | 不变量 | 违反时的后果 |
+|---|--------|-------------|
+| B1 | BranchPoint.candidateCount 必须等于其下 FutureBranch 数量 | 分叉结构不一致 |
+| B2 | `chooseBranch` 后恰好一个分支为 `chosen`，其余全部 `pruned` | 分叉未决策完 |
+| B3 | `chosen` / `pruned` 为终态，不可回退至 `pending` | 状态机违反 |
+| B4 | `chosenBranchId` 非 null 时必须指向一个 status=chosen 的 FutureBranch | 悬空引用 |
+| B5 | FutureBranch.branchPointId 必须指向已存在的 BranchPoint | 外键完整性 |
+| B6 | `getByEpisode` 返回顺序为 created_at ASC | 调用方依赖时序 |
+| B7 | `getBranches` 返回顺序为 score DESC | 调用方依赖排序 |
+
+---
+
+## §8 Pipeline 集成
+
+BranchPointStore 作为 `CausalPipeline` 的 `readonly branchPoints` 字段暴露。Pipeline 构造时根据 `PipelineConfig.branchPointDbPath` 初始化。
+
+```
+CausalPipeline
+  └── branchPoints: BranchPointStore
+        ├── saveBranchPoint()  ← recordFix 多候选时调用
+        ├── saveFutureBranch() ← 每条候选路径
+        ├── getByEpisode()     ← 审计
+        └── getPrunedBranches() ← 失败边界审计
+```
+
+---
+
+## §9 v13 简化代理声明
+
+当前实现为 v13 §8.1-8.2 的**简化代理**，与 v13 全 schema 存在以下差距：
+
+| v13 全 schema 特性 | 当前状态 | Gap |
+|-------------------|---------|-----|
+| `counterfactualTrace`：每个 pruned 分支关联反事实推演记录 | 未实现 | FutureBranch 仅存 `pruneReason` 文本，无结构化反事实 |
+| `temporalWindow`：分叉的时间窗口约束 | 未实现 | BranchPoint 无时间窗口字段 |
+| `confidenceInterval`：每条分支的置信区间 | 未实现 | FutureBranch 仅有单一 `score`，无区间 |
+| `cascadeEffect`：分支选择对下游 BranchPoint 的级联影响 | 未实现 | 当前各 BranchPoint 独立，无级联关系 |
+| `revisionHistory`：BranchPoint 决策的修订历史 | 未实现 | 当前 `chosen`/`pruned` 为终态不可修订 |
+
+升级路径：后续版本逐步引入上述字段，通过 schema 扩展（新增可选字段）保持向后兼容。
+
+---
+
+## §10 版本历史
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| 1 | 2026-04-15 | 初版。定义 BranchPoint + FutureBranch schema、状态机、BranchPointStore 持久化层、7 条不变量、v13 差距声明 |
+
+---
+
+## 参考
+
+- [[reconstruction-contract|AcceptedReconstruction 合同]] — 姊妹，Reconstruction 与 BranchPoint 在 recordFix 中同步产生
+- [[reconstruction-store-contract|ReconstructionStore 合同]] — 姊妹，同为 v11 治理对象持久化层

--- a/docs/current/reconstruction-store-contract.md
+++ b/docs/current/reconstruction-store-contract.md
@@ -1,0 +1,115 @@
+---
+kind: contract
+status: current
+implements:
+  - causal-learner/mcp-server/src/core/reconstruction-store.ts
+  - causal-learner/mcp-server/src/core/reconstruction.ts
+---
+
+# ReconstructionStore 合同：AcceptedReconstruction 持久化层
+
+> 定义 AcceptedReconstruction 的持久化职责、查询接口、存储不变量。
+> 上游依赖：[[reconstruction-contract|AcceptedReconstruction 合同]]
+> 关联实现：`core/reconstruction-store.ts`
+
+---
+
+## §1 职责
+
+ReconstructionStore 是 AcceptedReconstruction 的**唯一持久化入口**。pipeline 通过 `recordFix` 生成 AcceptedReconstruction 后，必须经由 ReconstructionStore 落盘，使其从临时返回值升级为可查询、可审计、可复用的一等治理对象。
+
+**是什么**：
+
+- SQLite（better-sqlite3）持久化层，WAL 模式
+- 按 `episode_id` 索引，支持按 Episode 查询全版本历史
+- 按 `fidelity_score` 索引，支持低 fidelity 审计查询
+
+**不是什么**：
+
+- 不负责创建 AcceptedReconstruction——创建逻辑在 `reconstruction.ts` 的 `createAcceptedReconstruction`
+- 不负责 fidelity 回归检查——回归逻辑由 OntologyDelta 提交流驱动
+- 不做 JSON schema 校验——信任上游 `createAcceptedReconstruction` 的类型约束
+
+---
+
+## §2 存储 Schema
+
+```sql
+CREATE TABLE reconstructions (
+  id              TEXT PRIMARY KEY,
+  episode_id      TEXT NOT NULL,
+  version         INTEGER NOT NULL,
+  fidelity_score  REAL NOT NULL,
+  created_at      TEXT NOT NULL,
+  created_by      TEXT NOT NULL,
+  data            TEXT NOT NULL          -- 完整 AcceptedReconstruction JSON
+);
+
+CREATE INDEX idx_rc_episode  ON reconstructions (episode_id);
+CREATE INDEX idx_rc_fidelity ON reconstructions (fidelity_score);
+```
+
+`data` 列存储 `JSON.stringify(AcceptedReconstruction)` 全量快照，其余列为查询热路径的冗余索引字段。
+
+---
+
+## §3 接口
+
+| 方法 | 签名 | 语义 |
+|------|------|------|
+| `save` | `(reconstruction: AcceptedReconstruction) => void` | INSERT OR REPLACE，幂等写入 |
+| `get` | `(id: string) => AcceptedReconstruction \| null` | 按主键精确查询 |
+| `getByEpisode` | `(episodeId: string) => AcceptedReconstruction[]` | 按 Episode 查询所有版本（version 降序） |
+| `getLowFidelity` | `(threshold: number, limit?: number) => AcceptedReconstruction[]` | fidelity 低于阈值的记录（升序），默认 limit=50 |
+| `getStats` | `() => ReconstructionStoreStats` | 返回 `{ totalCount }` |
+| `close` | `() => void` | 关闭数据库连接 |
+
+### §3.1 ReconstructionStoreStats
+
+```typescript
+interface ReconstructionStoreStats {
+  totalCount: number;
+}
+```
+
+---
+
+## §4 不变量
+
+| # | 不变量 | 违反时的后果 |
+|---|--------|-------------|
+| S1 | `data` 列 JSON 反序列化后必须符合 `AcceptedReconstruction` 接口 | 查询返回脏数据 |
+| S2 | `id` 全局唯一（PRIMARY KEY 约束） | 写入冲突 |
+| S3 | `save` 幂等：同 id 重复写入覆盖而非报错 | INSERT OR REPLACE 保证 |
+| S4 | `getByEpisode` 返回顺序为 version DESC | 调用方依赖首元素为最新版 |
+| S5 | 构造时自动创建目录 + 初始化表（若不存在） | 零配置启动 |
+| S6 | WAL 模式开启 | 并发读写安全 |
+
+---
+
+## §5 Pipeline 集成
+
+ReconstructionStore 作为 `CausalPipeline` 的 `readonly reconstructions` 字段暴露。Pipeline 构造时根据 `PipelineConfig.reconstructionDbPath` 初始化。
+
+```
+CausalPipeline
+  └── reconstructions: ReconstructionStore
+        ├── save()        ← recordFix 内部调用
+        ├── getByEpisode() ← 审计 / fidelity 回归查询
+        └── getLowFidelity() ← 低 fidelity 巡检
+```
+
+---
+
+## §6 版本历史
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| 1 | 2026-04-15 | 初版。定义 ReconstructionStore 职责、SQLite schema、6 个接口方法、6 条不变量 |
+
+---
+
+## 参考
+
+- [[reconstruction-contract|AcceptedReconstruction 合同]] — 上游，定义存储对象的完整 schema
+- [[artifact-contract|Artifact 合同]] — 落盘目录结构


### PR DESCRIPTION
## Summary

三线并行：

| 方向 | 产出 |
|---|---|
| docs/current 合约 | `reconstruction-store-contract.md` + `branch-point-contract.md` |
| BranchPoint v13 扩展 | +lineageId, +historicalSensitivity, +interventionIds, +predictedTrajectory, +informationGainEstimate |
| PresentSlice | `present-slice.ts` + `present-slice-store.ts`（HIGH 1 桥接对象） |

## Kilo 审计响应

- [x] "无 docs/current 合约" → 2 份合约已创建
- [x] "BranchPoint 是简化代理" → v13 字段已扩展（optional，向后兼容）
- [x] "PresentSlice 未实现" → 类型 + Store + buildFromPipeline 已创建

## Test plan

- [x] 152 tests pass, 0 fail
- [x] `tsc` 编译零错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)