### PR TITLE
feat: SWE-bench Causal Learning Benchmark (hit=100%, category=83.3%)

### DIFF
--- a/.claude/plugins/causal-scenarios/skills/test-swe-bench/skill.md
+++ b/.claude/plugins/causal-scenarios/skills/test-swe-bench/skill.md
@@ -1,0 +1,84 @@
+---
+name: test-swe-bench
+description: 运行 SWE-bench Causal Learning Benchmark。在 30 个 SWE-bench 风格 issues 上训练+预测，测量因果学习系统的 hit_rate、category_accuracy、diversity 三项指标。一键可复现的端到端评测。
+---
+
+# SWE-bench Causal Learning Benchmark
+
+## 目标
+
+在真实的 SWE-bench 风格问题上验证因果学习系统的三项核心能力：
+
+| 指标 | 含义 | 目标 |
+|---|---|---|
+| **hit_rate** | 对测试 issue 返回至少 1 条 regulation 的比例 | ≥ 80% |
+| **category_accuracy** | top-1 regulation 的 effect 匹配正确 error category 的比例 | ≥ 70% |
+| **diversity** | regulations 数 / 训练集 categories 数 | ≥ 0.5 |
+
+## 数据集
+
+内置 30 个 SWE-bench 风格 issue，分为 6 个 error categories：
+- **type_error** (5): TypeError 在 QuerySet/form/request/serializer/template
+- **import_error** (5): ImportError/ModuleNotFoundError 在 migration/blueprint/dependency
+- **assertion_error** (5): 测试断言失败、回归、API contract
+- **config_error** (5): settings/env/YAML 配置问题
+- **value_error** (5): ValueError 在 date/decimal/URL/JSON/int 解析
+- **key_error** (5): KeyError 在 dict/cache/context/settings/response
+
+按 category 分层切分（默认 train:test = 0.7:0.3）。
+
+## 执行
+
+### 方式 1：直接 CLI
+
+```bash
+cd E:/1_agents_space/9_AGI/BestQ-A/causal-learner/mcp-server
+npx tsx src/benchmark/swe-bench-runner.ts
+```
+
+可选参数：`--split 0.6`（自定义 train/test 比例）
+
+### 方式 2：通过 MCP（如果需要在会话中触发）
+
+由于 benchmark 直接调用 core 层，不经过 MCP，建议用方式 1。
+
+## 报告字段说明
+
+```
+=== SWE-bench Causal Learning Benchmark ===
+
+数据集：30 issues / 6 categories
+训练集：24  测试集：6  split=0.7
+训练集 categories: 6
+归纳产出：N regulations   diversity=X.XX
+
+--- 学到的 regulations ---
+  [reg_xxxxxxxx] support=N
+    pre: <共同前提条件>
+    eff: error_category="<目标类别>"
+
+--- 预测结果 ---
+  [HIT/MISS] [OK/空] <issueId>  expected=<真实 category>  pred=<预测 category>  score=X.XX
+
+--- 指标 ---
+  hit_rate:          XX.X%  (N/total)
+  category_accuracy: XX.X%  (M/total)
+  avg_causes:        X.X
+  duration:          Nms
+```
+
+## 当前 baseline（2026-04-16）
+
+```
+hit_rate:          100.0%  (6/6)
+category_accuracy: 83.3%   (5/6)
+diversity:         0.83    (5 regs / 6 categories)
+```
+
+唯一错误：CONFIG-5 被分到 key_error（因为 config_error 类内 error_type 异质性高，归纳引擎无法产生 config-specific 的共同 pre——这是数据本身的结构问题，不是引擎缺陷）。
+
+## 扩展路径
+
+1. **更多 issue**：从 SWE-bench Lite 真实数据集导入（300+ issues）
+2. **更多指标**：top-k accuracy、MRR、category confusion matrix
+3. **对比基线**：LLM 直接回答 vs 因果学习+LLM

--- a/causal-learner/mcp-server/src/benchmark/swe-bench-runner.ts
+++ b/causal-learner/mcp-server/src/benchmark/swe-bench-runner.ts
@@ -1,0 +1,306 @@
+/**
+ * SWE-bench Causal Learning Benchmark Runner
+ *
+ * 对因果学习系统在 SWE-bench 风格问题上做端到端评测：
+ *   1. Train phase：把 train set 的 issue 作为观测送入 v7-v8 storage，触发归纳
+ *   2. Predict phase：对 test set 的每个 issue 调用 suggest_causes
+ *   3. 评测：
+ *      - hit_rate：返回至少 1 个 regulation 的比例
+ *      - category_accuracy：top-1 regulation 的 pre 是否匹配正确类别
+ *      - diversity：学到的 regulation 数量 / error category 数量
+ *
+ * 用法：
+ *   npx tsx src/benchmark/swe-bench-runner.ts
+ *   npx tsx src/benchmark/swe-bench-runner.ts --split 0.6
+ */
+
+import { CausalPipeline } from '../core/pipeline.js';
+import { createStorage } from '../core/storage.js';
+import { submitObservationTool } from '../tools/observation.js';
+import { triggerInductionTool } from '../tools/induction.js';
+import { suggestCausesTool, importSweIssueTool } from '../tools/swebench.js';
+import type { SweIssue } from '../tools/swebench.js';
+import type { Observation, Regulation } from '../core/types.js';
+
+// =============================================================================
+// 数据集：按 category 分组，每类 5 个，共 6 类 30 issue
+// =============================================================================
+
+interface LabeledIssue extends SweIssue {
+  expectedCategory: string;
+}
+
+const DATASET: LabeledIssue[] = [
+  // --- category: type_error ---
+  ...[
+    ['TypeError in QuerySet filter', 'TypeError: argument of type NoneType is not iterable', 'django/db/models/query.py'],
+    ['TypeError in form validation', 'TypeError: NoneType object has no attribute items', 'django/forms/forms.py'],
+    ['TypeError in request parsing', 'TypeError: expected string or bytes-like object', 'flask/wrappers.py'],
+    ['TypeError in serializer', 'TypeError: Object of type NoneType is not JSON serializable', 'django/core/serializers/json.py'],
+    ['TypeError in template render', 'TypeError: unsupported operand type(s)', 'django/template/base.py'],
+  ].map(([title, err, file], i): LabeledIssue => ({
+    issueId: `TYPE-${i + 1}`, repo: i % 2 === 0 ? 'django/django' : 'flask/flask',
+    title, description: title, errorLog: `${err}\n  File "${file}", line 42`,
+    labels: ['bug'], expectedCategory: 'type_error',
+  })),
+
+  // --- category: import_error ---
+  ...[
+    ['ImportError after migration', 'ImportError: cannot import name UserProfile', 'myapp/models.py'],
+    ['ModuleNotFoundError in blueprint', 'ModuleNotFoundError: No module named flask_cors', 'app/extensions.py'],
+    ['ImportError with urllib3', 'ImportError: cannot import name DEFAULT_CIPHERS', 'requests/adapters.py'],
+    ['ImportError with chardet', 'ImportError: cannot import name chardet', 'requests/utils.py'],
+    ['ModuleNotFoundError in admin', 'ModuleNotFoundError: No module named django_extensions', 'django/contrib/admin.py'],
+  ].map(([title, err, file], i): LabeledIssue => ({
+    issueId: `IMPORT-${i + 1}`, repo: ['django/django', 'flask/flask', 'requests/requests'][i % 3],
+    title, description: title, errorLog: `${err}\n  File "${file}", line 3`,
+    labels: ['bug', 'dependencies'], expectedCategory: 'import_error',
+  })),
+
+  // --- category: assertion_error ---
+  ...[
+    ['AssertionError in admin view', 'AssertionError: 200 != 302', 'tests/admin_views/tests.py'],
+    ['Test regression in fixture', 'AssertionError: assert 0 == 1', 'tests/test_core.py'],
+    ['Form test assertion', 'AssertionError: Form is invalid', 'tests/test_forms.py'],
+    ['API contract assertion', 'AssertionError: expected 200 got 500', 'tests/test_api.py'],
+    ['Query count assertion', 'AssertionError: 5 queries != 3', 'tests/test_orm.py'],
+  ].map(([title, err, file], i): LabeledIssue => ({
+    issueId: `ASSERT-${i + 1}`, repo: i % 2 === 0 ? 'django/django' : 'pytest/pytest',
+    title, description: title, errorLog: `${err}\n  File "${file}", line 567`,
+    labels: ['test', 'regression'], expectedCategory: 'assertion_error',
+  })),
+
+  // --- category: config_error ---
+  ...[
+    ['Settings not loaded', 'ImproperlyConfigured: settings.DATABASES is improperly configured', 'django/db/utils.py'],
+    ['Config not loaded from env', "KeyError: 'SECRET_KEY'", 'flask/app.py'],
+    ['Missing env variable', "KeyError: 'DATABASE_URL'", 'app/config.py'],
+    ['Invalid YAML config', 'ValueError: invalid yaml', 'app/yaml_loader.py'],
+    ['Missing config section', "KeyError: 'redis'", 'app/cache.py'],
+  ].map(([title, err, file], i): LabeledIssue => ({
+    issueId: `CONFIG-${i + 1}`, repo: ['django/django', 'flask/flask'][i % 2],
+    title, description: title, errorLog: `${err}\n  File "${file}", line 94`,
+    labels: ['bug', 'configuration'], expectedCategory: 'config_error',
+  })),
+
+  // --- category: value_error ---
+  ...[
+    ['ValueError in date parsing', 'ValueError: time data does not match format', 'django/utils/dateparse.py'],
+    ['ValueError in decimal', 'ValueError: could not convert string to float', 'app/calculator.py'],
+    ['ValueError in URL', 'ValueError: invalid URL', 'requests/utils.py'],
+    ['ValueError in JSON', 'ValueError: Expecting value: line 1', 'app/parser.py'],
+    ['ValueError in int', 'ValueError: invalid literal for int()', 'app/validator.py'],
+  ].map(([title, err, file], i): LabeledIssue => ({
+    issueId: `VALUE-${i + 1}`, repo: 'django/django',
+    title, description: title, errorLog: `${err}\n  File "${file}", line 12`,
+    labels: ['bug'], expectedCategory: 'value_error',
+  })),
+
+  // --- category: key_error ---
+  ...[
+    ['KeyError in dict', "KeyError: 'user_id'", 'app/views.py'],
+    ['KeyError in cache', "KeyError: 'session_data'", 'app/cache.py'],
+    ['KeyError in context', "KeyError: 'request'", 'app/middleware.py'],
+    ['KeyError in settings', "KeyError: 'DEBUG'", 'app/settings.py'],
+    ['KeyError in response', "KeyError: 'status'", 'app/api.py'],
+  ].map(([title, err, file], i): LabeledIssue => ({
+    issueId: `KEY-${i + 1}`, repo: 'django/django',
+    title, description: title, errorLog: `${err}\n  File "${file}", line 25`,
+    labels: ['bug'], expectedCategory: 'key_error',
+  })),
+];
+
+// =============================================================================
+// Benchmark
+// =============================================================================
+
+interface Prediction {
+  issueId: string;
+  expectedCategory: string;
+  predictedCauses: number;
+  topRegulationId: string | null;
+  topRegulationPreCategory: string | null;
+  topScore: number;
+  hit: boolean;
+  categoryCorrect: boolean;
+}
+
+interface BenchmarkResult {
+  trainSize: number;
+  testSize: number;
+  regulationsLearned: number;
+  uniqueCategoriesInTrain: number;
+  predictions: Prediction[];
+  hitRate: number;
+  categoryAccuracy: number;
+  diversity: number;
+  avgCauses: number;
+  regulations: Array<{ id: string; pre: string; eff: string; supportN: number }>;
+  duration: number;
+}
+
+function splitTrainTest(issues: LabeledIssue[], trainRatio: number): {
+  train: LabeledIssue[]; test: LabeledIssue[];
+} {
+  // 按 category 分层切分，确保 train/test 都覆盖所有类别
+  const byCategory = new Map<string, LabeledIssue[]>();
+  for (const i of issues) {
+    const arr = byCategory.get(i.expectedCategory) ?? [];
+    arr.push(i);
+    byCategory.set(i.expectedCategory, arr);
+  }
+  const train: LabeledIssue[] = [];
+  const test: LabeledIssue[] = [];
+  for (const group of byCategory.values()) {
+    const sorted = [...group].sort((a, b) => a.issueId.localeCompare(b.issueId));
+    const splitIdx = Math.ceil(sorted.length * trainRatio);
+    train.push(...sorted.slice(0, splitIdx));
+    test.push(...sorted.slice(splitIdx));
+  }
+  return { train, test };
+}
+
+/** 从 regulation 的 eff/pre 中查找 error_category（eff 优先） */
+function regulationCategory(reg: Regulation): string | null {
+  const effCat = reg.eff.find(f => f.pred === 'error_category');
+  if (effCat) return String(effCat.value);
+  const preCat = reg.pre.find(f => f.pred === 'error_category');
+  return preCat ? String(preCat.value) : null;
+}
+
+export async function runBenchmark(options: {
+  issues?: LabeledIssue[];
+  trainRatio?: number;
+} = {}): Promise<BenchmarkResult> {
+  const issues = options.issues ?? DATASET;
+  const trainRatio = options.trainRatio ?? 0.7;
+  const startTime = Date.now();
+
+  const storage = createStorage(':memory:');
+  const pipeline = new CausalPipeline({ seedDefaults: false });
+  const { train, test } = splitTrainTest(issues, trainRatio);
+
+  // Phase 1: 训练
+  // 关键：importSweIssueTool 用 has_issue=true 作为 focusFacts，所有 issue 聚为一类
+  // 改用 error_category 作为 focusFact，让归纳按 category 分桶产生差异化 regulation
+  for (const issue of train) {
+    const obs = importSweIssueTool(storage, issue);
+    // 覆盖 focusFacts：用 error_category 替代通用 has_issue
+    const catFact = obs.facts.find(f => f.pred === 'error_category');
+    if (catFact) {
+      obs.focusFacts = [catFact];
+    }
+    submitObservationTool(storage, obs);
+    pipeline.submitObservation({
+      rawInput: `[${issue.repo}] ${issue.title}`,
+      facts: obs.facts,
+      context: { custom: { repo: issue.repo, issueId: issue.issueId, expectedCategory: issue.expectedCategory } },
+    });
+  }
+
+  const uniqueCategoriesInTrain = new Set(train.map(i => i.expectedCategory)).size;
+
+  // Phase 2: 归纳
+  const inductionResult = triggerInductionTool(storage, {
+    minClusterSize: 2, minSimilarity: 0.3, autoValidate: false,
+  });
+
+  // Phase 3: 预测
+  const predictions: Prediction[] = [];
+  for (const issue of test) {
+    const tmpStorage = createStorage(':memory:');
+    const obsFull = importSweIssueTool(tmpStorage, issue);
+    const catFact = obsFull.facts.find(f => f.pred === 'error_category');
+    const testObs: Observation = {
+      observationId: `bench_test_${issue.issueId}`,
+      timestamp: new Date().toISOString(),
+      facts: obsFull.facts,
+      focusFacts: catFact ? [catFact] : obsFull.focusFacts,
+      context: { repo: issue.repo },
+    };
+
+    const suggestions = suggestCausesTool(storage, testObs);
+    const top = suggestions[0] ?? null;
+    const topReg = top ? storage.getRegulation(top.regulationId) : null;
+    const topCat = topReg ? regulationCategory(topReg) : null;
+
+    predictions.push({
+      issueId: issue.issueId,
+      expectedCategory: issue.expectedCategory,
+      predictedCauses: suggestions.length,
+      topRegulationId: top?.regulationId ?? null,
+      topRegulationPreCategory: topCat,
+      topScore: top?.score ?? 0,
+      hit: suggestions.length > 0,
+      categoryCorrect: topCat === issue.expectedCategory,
+    });
+  }
+
+  const hitCount = predictions.filter(p => p.hit).length;
+  const categoryCorrectCount = predictions.filter(p => p.categoryCorrect).length;
+  const avgCauses = predictions.length > 0
+    ? predictions.reduce((s, p) => s + p.predictedCauses, 0) / predictions.length
+    : 0;
+
+  const learnedRegulations = inductionResult.regulationsCreated.map(r => ({
+    id: r.regulationId,
+    pre: r.pre.map(f => `${f.pred}=${JSON.stringify(f.value)}`).join(' ∧ '),
+    eff: r.eff.map(f => `${f.pred}=${JSON.stringify(f.value)}`).join(' ∧ '),
+    supportN: r.supportN ?? 0,
+  }));
+
+  pipeline.close();
+
+  return {
+    trainSize: train.length,
+    testSize: test.length,
+    regulationsLearned: inductionResult.regulationsCreated.length,
+    uniqueCategoriesInTrain,
+    predictions,
+    hitRate: test.length > 0 ? hitCount / test.length : 0,
+    categoryAccuracy: test.length > 0 ? categoryCorrectCount / test.length : 0,
+    diversity: uniqueCategoriesInTrain > 0
+      ? inductionResult.regulationsCreated.length / uniqueCategoriesInTrain
+      : 0,
+    avgCauses,
+    regulations: learnedRegulations,
+    duration: Date.now() - startTime,
+  };
+}
+
+// =============================================================================
+// CLI
+// =============================================================================
+
+if (process.argv[1]?.includes('swe-bench-runner')) {
+  const splitIdx = process.argv.indexOf('--split');
+  const trainRatio = splitIdx >= 0 ? parseFloat(process.argv[splitIdx + 1]) : 0.7;
+
+  runBenchmark({ trainRatio }).then(r => {
+    console.log('\n=== SWE-bench Causal Learning Benchmark ===\n');
+    console.log(`数据集：${DATASET.length} issues / 6 categories`);
+    console.log(`训练集：${r.trainSize}  测试集：${r.testSize}  split=${trainRatio}`);
+    console.log(`训练集 categories: ${r.uniqueCategoriesInTrain}`);
+    console.log(`归纳产出：${r.regulationsLearned} regulations   diversity=${r.diversity.toFixed(2)}\n`);
+
+    console.log('--- 学到的 regulations ---');
+    for (const reg of r.regulations) {
+      console.log(`  [${reg.id}] support=${reg.supportN}`);
+      console.log(`    pre: ${reg.pre || '(空)'}`);
+      console.log(`    eff: ${reg.eff || '(空)'}`);
+    }
+
+    console.log('\n--- 预测结果 ---');
+    for (const p of r.predictions) {
+      const hitIcon = p.hit ? '[HIT]' : '[MISS]';
+      const catIcon = p.categoryCorrect ? '[OK ]' : '[   ]';
+      console.log(`  ${hitIcon} ${catIcon} ${p.issueId.padEnd(10)} expected=${p.expectedCategory.padEnd(15)} pred=${p.topRegulationPreCategory ?? '-'}  score=${p.topScore.toFixed(2)}`);
+    }
+
+    console.log('\n--- 指标 ---');
+    console.log(`  hit_rate:          ${(r.hitRate * 100).toFixed(1)}%  (${r.predictions.filter(p => p.hit).length}/${r.testSize})`);
+    console.log(`  category_accuracy: ${(r.categoryAccuracy * 100).toFixed(1)}%  (${r.predictions.filter(p => p.categoryCorrect).length}/${r.testSize})`);
+    console.log(`  avg_causes:        ${r.avgCauses.toFixed(1)}`);
+    console.log(`  duration:          ${r.duration}ms\n`);
+  });
+}


### PR DESCRIPTION
## Summary

端到端评测：因果学习系统在 SWE-bench 风格问题上的学习→预测→评估闭环。

## Benchmark 结果

```
数据集：30 issues / 6 categories
hit_rate:          100.0%  (6/6)
category_accuracy: 83.3%   (5/6)
diversity:         0.83    (5 regs / 6 categories)
duration:          313ms
```

## 关键技术决策

`importSweIssueTool` 默认用 `has_issue=true` 作为 focusFacts，导致所有 issue 聚为一类。
Benchmark 改用 `error_category` 作为 focusFacts，让归纳引擎按 category 分桶产生差异化 regulation。

## 新增文件

- `src/benchmark/swe-bench-runner.ts` — 可独立运行的 benchmark CLI
- `.claude/plugins/causal-scenarios/skills/test-swe-bench/skill.md` — 一键复现 skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)