### PR TITLE
feat: 诊断推理引擎 — event 证据链 + diagnose_problem + suggestCauses 修复 (#76)

### DIFF
--- a/causal-learner/mcp-server/src/core/inducer.ts
+++ b/causal-learner/mcp-server/src/core/inducer.ts
@@ -293,6 +293,8 @@ export function induceRegulation(
       inducedAt: nowIso(),
       inducedMethod: 'cluster_intersection+missing_pre+common_context',
     },
+    // event 证据链：归纳来源的 events 即初始确认证据
+    confirmedByEvents: cluster.map((e) => e.eventId),
     nextTests: [],
     tags: ['induced'],
   };

--- a/causal-learner/mcp-server/src/core/knowledge-composition.ts
+++ b/causal-learner/mcp-server/src/core/knowledge-composition.ts
@@ -53,12 +53,21 @@ export function getLevel(reg: Regulation): number {
 export function computeTrust(reg: Regulation): number {
   const support = reg.supportN ?? 0;
   const counter = reg.counterexampleN ?? 0;
-  const total = support + counter;
 
-  if (total === 0) return 0.1; // 无证据时给最低信任
+  // event 证据链：真实的历史观测支撑
+  const confirmedEvents = reg.confirmedByEvents?.length ?? 0;
+  const challengedEvents = reg.challengedByEvents?.length ?? 0;
 
-  // 基础信任：support 比例
-  const successRate = support / total;
+  // 合并：统计 support + event 确认
+  const totalSupport = support + confirmedEvents;
+  const totalChallenge = counter + challengedEvents;
+  const total = totalSupport + totalChallenge;
+
+  // 无任何 event 支撑 = 猜测，不是知识
+  if (total === 0) return 0.05;
+
+  // 基础信任：成功率
+  const successRate = totalSupport / total;
 
   // 样本量加权：样本越多越可信（对数增长，避免大数垄断）
   const sampleWeight = Math.min(1.0, Math.log2(total + 1) / 10);

--- a/causal-learner/mcp-server/src/core/types.ts
+++ b/causal-learner/mcp-server/src/core/types.ts
@@ -383,10 +383,14 @@ export interface Regulation {
   nextTests?: Record<string, unknown>[];
   tags?: string[];
   metadata?: Record<string, unknown>;
-  /** 知识层级：0=公理（基本事实），1+=定理（从更基本的知识组合派生） */
+  /** 知识层级：0=基础观测归纳，1+=从更基本的知识组合派生 */
   level?: number;
   /** 本条知识从哪些更基本的 regulation 组合派生（引用链） */
   derivedFrom?: string[];
+  /** 确认本条知识的 event IDs（每次 event 验证成功时追加） */
+  confirmedByEvents?: string[];
+  /** 挑战本条知识的 event IDs（每次 event 反驳时追加） */
+  challengedByEvents?: string[];
 }
 
 /**

--- a/causal-learner/mcp-server/src/core/validator.ts
+++ b/causal-learner/mcp-server/src/core/validator.ts
@@ -258,7 +258,8 @@ function effectsPresent(reg: Regulation, obs: Observation): boolean {
 export function validateWithObservation(
   reg: Regulation,
   obs: Observation,
-  actualOutcome: boolean
+  actualOutcome: boolean,
+  eventId?: string
 ): void {
   // Check if preconditions are satisfied
   const preSatisfied = preSatisfiedInObservation(reg, obs);
@@ -275,10 +276,18 @@ export function validateWithObservation(
     // Supporting evidence
     reg.supportN = (reg.supportN || 0) + 1;
     reg.explainedCount = (reg.explainedCount || 0) + 1;
+    // event 证据链：追加确认 event
+    if (eventId) {
+      reg.confirmedByEvents = [...(reg.confirmedByEvents ?? []), eventId];
+    }
   } else {
     // Contradicting evidence
     reg.counterexampleN = (reg.counterexampleN || 0) + 1;
     reg.failedPredictions = (reg.failedPredictions || 0) + 1;
+    // event 证据链：追加挑战 event
+    if (eventId) {
+      reg.challengedByEvents = [...(reg.challengedByEvents ?? []), eventId];
+    }
   }
 
   // Update last used timestamp

--- a/causal-learner/mcp-server/src/index.ts
+++ b/causal-learner/mcp-server/src/index.ts
@@ -736,7 +736,32 @@ const TOOLS: Tool[] = [
       required: ['text'],
     },
   },
-// 诊断推理工具  {    name: 'diagnose_problem',    description: 'Diagnostic reasoning: given incomplete facts about a problem, identify candidate explanations, generate targeted questions for missing info, and provide recommendations once converged.',    inputSchema: {      type: 'object',      properties: {        facts: { type: 'array', items: { type: 'object' }, description: 'Known facts about the problem' },        context: { type: 'object', description: 'Optional context (project, env, etc.)' },      },      required: ['facts'],    },  },  {    name: 'update_diagnosis',    description: 'Update a diagnosis with new facts (answers to previous questions). Re-runs diagnostic reasoning with combined old+new facts.',    inputSchema: {      type: 'object',      properties: {        previousFacts: { type: 'array', items: { type: 'object' }, description: 'Facts from previous diagnosis' },        newFacts: { type: 'array', items: { type: 'object' }, description: 'Newly provided facts (answers to questions)' },        context: { type: 'object' },      },      required: ['previousFacts', 'newFacts'],    },  },
+  // 诊断推理工具
+  {
+    name: 'diagnose_problem',
+    description: 'Diagnostic reasoning: given incomplete facts about a problem, identify candidate explanations, generate targeted questions for missing info, and provide recommendations once converged.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        facts: { type: 'array', items: { type: 'object' }, description: 'Known facts about the problem' },
+        context: { type: 'object', description: 'Optional context (project, env, etc.)' },
+      },
+      required: ['facts'],
+    },
+  },
+  {
+    name: 'update_diagnosis',
+    description: 'Update a diagnosis with new facts (answers to previous questions). Re-runs diagnostic reasoning with combined old+new facts.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        previousFacts: { type: 'array', items: { type: 'object' }, description: 'Facts from previous diagnosis' },
+        newFacts: { type: 'array', items: { type: 'object' }, description: 'Newly provided facts (answers to questions)' },
+        context: { type: 'object' },
+      },
+      required: ['previousFacts', 'newFacts'],
+    },
+  },
 ];
 
 // Generate unique observation ID
@@ -1356,8 +1381,22 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return { content: [{ type: 'text', text: JSON.stringify(suggestions, null, 2) }] };
       }
 
+      // 诊断推理
+      case 'diagnose_problem': {
+        const facts = (args?.facts as Fact[]) || [];
+        const ctx = args?.context as Record<string, unknown> | undefined;
+        const result = diagnose(storage, facts, ctx);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      }
+      case 'update_diagnosis': {
+        const prevFacts = (args?.previousFacts as Fact[]) || [];
+        const newFacts = (args?.newFacts as Fact[]) || [];
+        const ctx2 = args?.context as Record<string, unknown> | undefined;
+        const result = updateDiagnosis(storage, prevFacts, newFacts, ctx2);
+        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      }
+
       // 自然语言解析 + 提交
-// 诊断推理      case 'diagnose_problem': {        const facts = (args?.facts as Fact[]) || [];        const ctx = args?.context as Record<string, unknown> | undefined;        const result = diagnose(storage, facts, ctx);        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };      }      case 'update_diagnosis': {        const prevFacts = (args?.previousFacts as Fact[]) || [];        const newFacts = (args?.newFacts as Fact[]) || [];        const ctx2 = args?.context as Record<string, unknown> | undefined;        const result = updateDiagnosis(storage, prevFacts, newFacts, ctx2);        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };      }
       case 'parse_and_submit': {
         const text = args?.text as string;
         if (!text || typeof text !== 'string') {

--- a/causal-learner/mcp-server/src/tools/induction.ts
+++ b/causal-learner/mcp-server/src/tools/induction.ts
@@ -340,6 +340,8 @@ function generateRegulationsFromCluster(
         eventIds: cluster.eventIds,
         created: new Date().toISOString(),
       },
+      // event 证据链：归纳来源的 events 即初始确认证据
+      confirmedByEvents: [...cluster.eventIds],
       tags: ['induced'],
     };
 

--- a/causal-learner/mcp-server/src/tools/swebench.ts
+++ b/causal-learner/mcp-server/src/tools/swebench.ts
@@ -356,17 +356,22 @@ export function suggestCausesTool(
   const obsPreds = new Set(obs.facts.map(f => f.pred));
 
   for (const reg of regulations) {
-    // eff 匹配：已知 facts 中有多少匹配 regulation 的 eff
+    // eff 匹配：已知 facts 中有多少匹配 regulation 的 eff（反向推理：观测现象 → 匹配规律的结果集）
     let effOverlap = 0;
-    for (const eff of reg.eff) {
-      if (obsSigs.has(`${eff.pred}|${JSON.stringify(eff.value)}`)) effOverlap++;
-      else if (obsPreds.has(eff.pred)) effOverlap += 0.5; // pred 相同值不同：半分
-    }
-
-    // pre 匹配：已知 facts 中有多少匹配 regulation 的 pre
-    let preOverlap = 0;
     const matchedPreds: string[] = [];
     const missingPreds: string[] = [];
+    for (const eff of reg.eff) {
+      if (obsSigs.has(`${eff.pred}|${JSON.stringify(eff.value)}`)) {
+        effOverlap++;
+        matchedPreds.push(eff.pred);            // ← Bug1 修复：eff 命中也记录
+      } else if (obsPreds.has(eff.pred)) {
+        effOverlap += 0.5; // pred 相同值不同：半分
+        matchedPreds.push(`~${eff.pred}`);
+      }
+    }
+
+    // pre 匹配：已知 facts 中有多少匹配 regulation 的 pre（前提条件已确认）
+    let preOverlap = 0;
     for (const pre of reg.pre) {
       if (obsSigs.has(`${pre.pred}|${JSON.stringify(pre.value)}`)) {
         preOverlap++;
@@ -379,8 +384,13 @@ export function suggestCausesTool(
       }
     }
 
-    const totalFields = (reg.eff.length + reg.pre.length) || 1;
-    const overlapScore = (effOverlap + preOverlap) / totalFields;
+    const effLen = reg.eff.length || 1;
+    const preLen = reg.pre.length || 1;
+    // Bug2 修复：confidence 用 effMatchRatio（观测现象覆盖 eff 的比例）而非稀释后的 overlapScore
+    const effMatchRatio = effOverlap / effLen;
+    const preMatchRatio = preOverlap / preLen;
+    // 综合分：eff 覆盖度权重 0.7（诊断核心），pre 确认度权重 0.3
+    const overlapScore = effMatchRatio * 0.7 + preMatchRatio * 0.3;
 
     // 至少有一个字段匹配才纳入候选
     if (overlapScore > 0) {
@@ -388,8 +398,8 @@ export function suggestCausesTool(
       const score = overlapScore * regCredibility;
 
       let confidence: 'high' | 'medium' | 'low' = 'low';
-      if (overlapScore > 0.6) confidence = 'high';
-      else if (overlapScore > 0.3) confidence = 'medium';
+      if (effMatchRatio > 0.6) confidence = 'high';
+      else if (effMatchRatio > 0.3) confidence = 'medium';
 
       // 构造修复建议
       let suggestedFix: string | undefined;

--- a/docs/current/branch-point-contract.md
+++ b/docs/current/branch-point-contract.md
@@ -1,6 +1,7 @@
 ---
 kind: contract
 status: current
+describes: BranchPointStore
 implements:
   - causal-learner/mcp-server/src/core/branch-point.ts
   - causal-learner/mcp-server/src/core/branch-point-store.ts

--- a/docs/current/reconstruction-store-contract.md
+++ b/docs/current/reconstruction-store-contract.md
@@ -1,6 +1,7 @@
 ---
 kind: contract
 status: current
+describes: ReconstructionStore
 implements:
   - causal-learner/mcp-server/src/core/reconstruction-store.ts
   - causal-learner/mcp-server/src/core/reconstruction.ts

--- a/docs/design_history/v13_historical_generative_ontology.md
+++ b/docs/design_history/v13_historical_generative_ontology.md
@@ -1,0 +1,738 @@
+# 递归式问答系统 v13：历史生成本体引擎
+
+> 副标题：没有没有历史的当下；理解是来源重建；未来是可干预分叉的延拓
+
+---
+
+## 0. 一句定义
+
+因为不存在一个没有历史的当下，所以任何当前状态都不是孤立点，而是历史机制、约束、失败剪枝、局部干预和观测位置共同压缩出来的结果。
+
+因为理解一个问题，不是给它贴标签，而是还原它怎样成为现在这样，所以 v13 定义为：
+
+> **一个把当前状态视为历史压缩态，把解释视为最小充分追溯，把规划视为来源链上可干预分叉延拓的历史生成本体引擎。**
+
+再压缩成一句：
+
+> **v13 = 谱系过程本体（Genealogical Process Ontology）**
+
+---
+
+## 1. 历史位置
+
+v13 不是对 v6-v11 的否定，而是把它们共同指向的一条更深公理明确写出来：
+
+```text
+v1  递归分解：复杂能力可分解
+v2  抽象类系统：类 / 实例 / 条件路由
+v3  语义接龙：问题必须放回更大上下文理解
+v4  可组合知识：原子与组合显式分离
+v5  图与双模式：知识是图，不是规则列表
+v6  关系法律：关系必须有签名与组合约束
+v7  世界动力学：Episode / State / Transition / Reconstruction
+v8  生成模拟：反事实与实验设计
+v9  本体联邦：多局部本体、翻译与冲突
+v10  参与式自反：观察者、仪器、部署也是世界的一部分
+v11  文明记忆：失败边界、proof lineage、制度化编译
+v13 历史生成本体：当前状态必须带谱系，未来必须从谱系分叉
+```
+
+v13 不是把前面版本抹掉，而是把它们统一到一个更高的中心问题上：
+
+```text
+当前是怎样变成现在这样的？
+在不改写历史的前提下，未来还能从哪里分叉？
+```
+
+---
+
+## 2. v13 的根公理
+
+### G1. 没有没有历史的当下
+
+任何当前结果都不是“突然出现”的。
+
+它总来自：
+
+- 上游状态
+- 触发机制
+- 长期约束
+- 历史失败边界
+- 局部干预与制度筛选
+
+所以系统不得把“当前状态”视为无来源对象。
+
+### G2. 当前状态是历史的压缩态
+
+Present 不是一个点，而是：
+
+```text
+多条历史链
++ 已被剪掉的失败分支
++ 尚未展开的潜在分支
+在当前时刻的压缩投影
+```
+
+因此，State 不只是值，还必须带 lineage。
+
+### G3. 理解不是分类，而是最小充分追溯
+
+理解一个问题，不是找到一个最像的标签，而是还原出：
+
+- 近因：这次直接发生了什么
+- 中因：为什么它会在这里被触发
+- 远因：哪些长期结构或历史边界让它呈现为今天的样子
+
+但追溯不能无限展开，因此 v13 追求的是：
+
+> **Minimal Sufficient Provenance**
+
+即：足以解释当前状态为何成为现在这样、且不再多余膨胀的最小来源链。
+
+### G4. 未来不是凭空预测，而是历史链上的可干预延拓
+
+因为未来是从当下分叉出来的，而当下又是历史压缩态，所以未来规划不该被定义为“猜一个方向”，而应被定义为：
+
+> **在已重建的来源链上找到关键 branch point，并评估可干预分叉。**
+
+### G5. 失败不是目的，而是被剪掉的可能性空间
+
+失败不是第一原则，也不是中心对象。
+
+失败的真正地位是：
+
+- 它属于 possibility space
+- 它界定了确定性的负片
+- 它标示了哪些分支曾经存在、后来被代价和经验剪掉
+
+因此，失败不是噪声，而是边界。
+
+### G6. 统一整体只能是极限结构，不能是先验假设
+
+v13 允许所有现态都指向更大的整体来源，但禁止系统先验写死“唯一终极整体已经已知”。
+
+所以：
+
+- 全局统一必须由局部 lineage convergence 逐层证明
+- 不能用叙事填补未知来源链
+- 不可通约边界必须保留，而不是被大一统修辞抹掉
+
+---
+
+## 3. 与 v11 相比，v13 真正改变了什么
+
+v11 的中心已经不再是“回答”，而是：
+
+- 观察者
+- 仪器
+- 失败边界
+- 制度化编译
+- 文明记忆
+
+v13 继续往前推进一步：
+
+### 3.1 从“世界如何被记住”变成“当前如何由历史生成”
+
+v11 更强调：
+
+- 哪些失败不能丢
+- 哪些 proof lineage 必须跨代保存
+- 哪些冲突不能静默消失
+
+v13 则更强调：
+
+- 当前状态一定带谱系
+- 当前解释一定要还原来源
+- 当前规划一定要回到来源链上选分叉点
+
+### 3.2 从“重建过程”变成“重建来源”
+
+v7-v11 已经很重视 replayable reconstruction。
+
+v13 进一步要求：
+
+- 不是只回答“过程怎样发生”
+- 还要回答“为什么这个过程会以这样的形式被历史塑造出来”
+
+### 3.3 从“Episode 是采样”变成“Episode 是谱系切片”
+
+Episode 不再只是一次经历，而是：
+
+> 在某个观察位置下，对一条更长历史链的局部切片。
+
+### 3.4 从“未来是实验与规划”变成“未来是 branch governance”
+
+v8-v11 已经引入反事实和实验设计。
+
+v13 则把未来提升成：
+
+- branch discovery
+- branch pruning
+- branch protection
+- branch activation
+
+未来不再只是 predicted trajectory，而是 lineage-preserving branching policy。
+
+---
+
+## 4. v13 的七层架构
+
+```text
+┌────────────────────────────────────────────┐
+│ Civilization Memory Layer                  │
+│ proof lineage / failure lineage /          │
+│ historical branch archive                  │
+├────────────────────────────────────────────┤
+│ Institutional Compile Layer                │
+│ lineage compile / challenge / rollback     │
+├────────────────────────────────────────────┤
+│ Ontology Federation Layer                  │
+│ local ontologies / translations /          │
+│ lineage convergence                        │
+├────────────────────────────────────────────┤
+│ Branching & Counterfactual Layer           │
+│ branch point / future branch / intervention│
+├────────────────────────────────────────────┤
+│ Provenance & Reconstruction Layer          │
+│ present slice / provenance lineage /       │
+│ minimal sufficient trace                    │
+├────────────────────────────────────────────┤
+│ Episode / Observer / Instrument Layer      │
+│ positioned observations / actions / outcome│
+├────────────────────────────────────────────┤
+│ World-Historical Layer                     │
+│ entities / states / mechanisms /           │
+│ historical constraints                     │
+└────────────────────────────────────────────┘
+```
+
+因为 v13 的中心不是静态事实，所以世界层也必须是 world-historical，而不是纯分类本体。
+
+---
+
+## 5. 世界历史层（World-Historical Layer）
+
+### 5.1 基础对象
+
+```typescript
+interface EntityClass {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface StateVarClass {
+  id: string;
+  ownerEntityClassId: string;
+  name: string;
+  valueType: string;
+  semantics: string;
+}
+
+interface HistoricalConstraint {
+  id: string;
+  name: string;
+  description: string;
+  kind: 'physical' | 'institutional' | 'resource' | 'historical_boundary';
+  activeScopes: string[];
+  inheritedFrom?: string[];
+}
+
+interface HistoricalMechanism {
+  id: string;
+  name: string;
+  inputs: string[];
+  preconditions: string[];
+  phases: string[];
+  observableSignatures: string[];
+  outcomes: string[];
+  failsWhen: string[];
+  historicalDependencies: string[];
+  validityEnvelope: string[];
+}
+```
+
+### 5.2 为什么 Constraint 要变成 HistoricalConstraint
+
+因为很多今天看似自然的边界，其实不是天生如此，而是历史失败、制度改造、工程经验和资源约束共同形成的。
+
+所以 v13 里的约束不能只写“现在约束是什么”，还必须写：
+
+- 它从哪里来
+- 它替代了什么旧边界
+- 它是被什么失败历史逼出来的
+
+---
+
+## 6. Episode 层：从“经历”升级为“谱系切片”
+
+```typescript
+interface Episode {
+  id: string;
+  context: Record<string, unknown>;
+  observerIds: string[];
+  instrumentIds: string[];
+  timeline: TimelineStep[];
+  observations: string[];
+  actions: string[];
+  outcomes: string[];
+  presentSliceId?: string;
+  linkedLineages?: string[];
+}
+
+interface TimelineStep {
+  t: number | string;
+  stateSnapshotId: string;
+}
+
+interface ObservationRecord {
+  id: string;
+  observerId: string;
+  instrumentId: string;
+  rawTrace: string;
+  extractedSignals: string[];
+  blindSpots: string[];
+  timestamp: string;
+}
+```
+
+### 6.1 v13 对 Episode 的新判断
+
+因为 Episode 不是完整历史，而只是局部切片，所以它必须同时保存：
+
+- 当前看到了什么
+- 当前看不到什么
+- 当前切到了哪条 lineage 的哪一段
+- 哪些上游历史仍未被恢复
+
+也就是说，Episode 不是完整故事，而是：
+
+> **对更长来源链的一次带位置采样。**
+
+---
+
+## 7. Provenance & Reconstruction Layer：谱系与重建层
+
+这是 v13 的核心新增层。
+
+### 7.1 PresentSlice
+
+```typescript
+interface PresentSlice {
+  id: string;
+  episodeId: string;
+  stateSnapshotIds: string[];
+  activeConstraints: string[];
+  visibleOutcomes: string[];
+  inferredLatentStates?: string[];
+  unresolvedUnknowns?: string[];
+}
+```
+
+PresentSlice 不是整个 Episode，而是：
+
+- 在当前时刻真正需要解释的状态压缩面
+- 之后一切 provenance tracing 的起点
+
+### 7.2 ProvenanceStep 与 ProvenanceLineage
+
+```typescript
+interface ProvenanceStep {
+  id: string;
+  fromStateId?: string;
+  toStateId?: string;
+  mechanismId?: string;
+  constraintIds?: string[];
+  supportingObservationIds?: string[];
+  confidence: number;
+}
+
+interface ProvenanceLineage {
+  id: string;
+  targetPresentSliceId: string;
+  steps: ProvenanceStep[];
+  nearCauseSegment: string[];
+  midCauseSegment: string[];
+  deepCauseSegment: string[];
+  minimalityJustification: string;
+  unresolvedGaps: string[];
+}
+```
+
+### 7.3 Minimal Sufficient Provenance
+
+v13 明确要求：
+
+任何被接受的解释都不只是一个 mechanism chain，而必须给出：
+
+- near cause
+- mid cause
+- deep cause
+- why this lineage is sufficient
+- which parts remain unresolved
+
+也就是说，Accepted Reconstruction 在 v13 中升级为：
+
+> **Accepted Provenance Reconstruction**
+
+### 7.4 为什么“最小充分追溯”是硬要求
+
+因为如果没有 minimality，系统会无限倒历史，最后失去操作性。  
+因为如果没有 sufficiency，系统会只给一个局部借口，失去解释力。
+
+所以 v13 的解释标准不是“追得越远越好”，而是：
+
+> **追到刚好足以解释当前，并能为未来分叉提供行动边界。**
+
+---
+
+## 8. Branching & Counterfactual Layer：分叉与反事实层
+
+### 8.1 BranchPoint
+
+```typescript
+interface BranchPoint {
+  id: string;
+  lineageId: string;
+  locationDescription: string;
+  controllableFactors: string[];
+  uncontrollableFactors: string[];
+  historicalSensitivity: string[];
+}
+```
+
+### 8.2 FutureBranch
+
+```typescript
+interface FutureBranch {
+  id: string;
+  branchPointId: string;
+  interventionIds: string[];
+  predictedTrajectory: string[];
+  predictedOutcomes: string[];
+  riskProfile: string[];
+  informationGainEstimate?: number;
+}
+```
+
+### 8.3 v13 对未来规划的重新定义
+
+未来规划不再被定义成：
+
+- 给出建议
+- 猜可能结果
+- 选择一个优化方向
+
+而被定义成：
+
+> **在 provenance lineage 上找到 branch point，然后评估哪些干预最值得激活、哪些分支最值得剪掉、哪些失败边界必须继续守住。**
+
+因此，反事实在 v13 中的地位更加明确：
+
+- 不是语言游戏
+- 不是想象练习
+- 而是 lineage governance 的工具
+
+---
+
+## 9. Failure 在 v13 中的位置：Pruned Possibility Space
+
+因为失败不是第一原则，所以 v13 不会把所有东西都围着失败转。
+
+但因为失败是确定性的负片，所以 v13 必须把 possibility space 写成显式对象：
+
+```typescript
+interface PossibilitySpace {
+  id: string;
+  presentSliceId: string;
+  feasibleRegion: string[];
+  prunedRegion: string[];
+  unknownRegion: string[];
+}
+
+interface PrunedBranchRecord {
+  id: string;
+  branchDescription: string;
+  prunedBy: string[];              // failure, institution, design, physics
+  definingEpisodes: string[];
+  reactivationRisks: string[];
+}
+```
+
+### 9.1 为什么失败要以“pruned branch”保存
+
+因为很多失败后来会不再上演，于是后代会误以为“这种错误从来不是真实分支”。
+
+v13 要保留的是：
+
+- 这个分支曾经真实存在
+- 它如何被证明不可行
+- 它被什么代价剪掉
+- 在什么条件变化下它可能重新打开
+
+也就是说，失败边界在 v13 中被进一步解释为：
+
+> **被历史剪掉的真实分支。**
+
+---
+
+## 10. Ontology Federation Layer：从多本体到 lineage convergence
+
+v13 不否定 v9 的本体联邦。  
+但 v13 给它加了一个更强的收敛标准：
+
+> **多个本体能否接近统一，不只看对象映射能否成立，还要看它们对同一 present slice 的 provenance reconstruction 是否收敛。**
+
+### 10.1 新对象：LineageConvergenceRecord
+
+```typescript
+interface LineageConvergenceRecord {
+  id: string;
+  targetPresentSliceId: string;
+  ontologyIds: string[];
+  reconstructedLineageIds: string[];
+  sharedSegments: string[];
+  divergingSegments: string[];
+  translationLosses: string[];
+  status: 'converging' | 'diverging' | 'incommensurable';
+}
+```
+
+### 10.2 为什么统一不能只看概念映射
+
+因为两个 ontology 可以把对象翻译得很像，但如果它们对“这个当下是怎样变成今天这样”的解释长期不收敛，那么它们还没有真正共享现实。
+
+因此 v13 把统一标准提升为：
+
+- object mapping
+- invariant preservation
+- lineage convergence
+- conflict retention
+
+缺一不可。
+
+---
+
+## 11. Institutional Compile Layer：从 compile proposal 到 lineage compile
+
+因为 v13 的核心资产不再只是 claim，而是 lineage，所以 compile 也必须升级。
+
+### 11.1 LineageCompileProposal
+
+```typescript
+interface LineageCompileProposal {
+  id: string;
+  targetPresentSliceId: string;
+  proposedLineageId: string;
+  supportingEpisodes: string[];
+  counterexampleIds: string[];
+  prunedBranchRefs: string[];
+  branchGovernanceImplications: string[];
+  status: 'draft' | 'challenged' | 'approved' | 'rejected' | 'rolled_back';
+}
+```
+
+### 11.2 v13 的 compile 条件
+
+任何 lineage 进入 compiled memory，至少需要：
+
+1. 有 positioned observations 支持
+2. 有 replay 或 equivalent reconstruction 支持
+3. 有最小充分性论证
+4. 有已知 pruned branches 的引用
+5. 有对 future branch governance 的说明
+6. 若涉及跨本体，必须有 lineage convergence 审理
+
+因为 v13 不是存答案，而是存“当前如何由历史生成”的公共解释骨架。
+
+---
+
+## 12. Civilization Memory Layer：文明记忆层的升级
+
+v11 已经把 proof lineage 和 failure boundary 提升到顶层。  
+v13 则进一步要求文明记忆保存：
+
+- current states 的 lineage
+- 被剪掉的 branch histories
+- 失败边界如何定义今天的确定性
+- 哪些 future branches 仍开放
+
+### 12.1 新对象：HistoricalCompressionRecord
+
+```typescript
+interface HistoricalCompressionRecord {
+  id: string;
+  presentSliceId: string;
+  acceptedLineageId: string;
+  retainedFailureBoundaries: string[];
+  openFutureBranches: string[];
+  summary: string;
+}
+```
+
+这个对象保存的是：
+
+> **这个当下，究竟压缩了哪些历史。**
+
+这会成为未来智能体最宝贵的资产之一，因为它告诉后来者：
+
+- 现在为什么看起来这么“自然”
+- 这种自然感背后，哪些失败已经被历史抹平
+- 哪些分叉仍值得继续探索
+
+---
+
+## 13. v13 的新法律
+
+### L1. No Present Without Lineage
+
+任何 PresentSlice，如果没有 provenance lineage，不得被编译成稳定知识。
+
+### L2. No Ahistorical Compile
+
+任何 compiled claim、mechanism、policy，都必须带：
+
+- provenance lineage
+- failure boundary
+- pruned branch refs
+- validity envelope
+
+### L3. Explanation Must Be Minimally Sufficient
+
+任何 accepted explanation，都必须说明：
+
+- 为什么这条 lineage 足够
+- 为什么继续向更深历史追溯暂时不再必要
+- 哪些 unresolved gaps 被显式保留
+
+### L4. Prediction Must Declare Branch Point
+
+任何未来规划，都必须回指：
+
+- 从哪条 lineage 分叉
+- 在哪个 branch point 分叉
+- 通过哪个干预触发分叉
+
+### L5. Certainty Carries Pruned Alternatives
+
+任何确定知识，都必须显式带着：
+
+- 曾经存在的失败分支
+- 已被剪掉的 alternative paths
+- 重新激活这些路径的风险
+
+### L6. Unity Requires Lineage Convergence
+
+任何声称“更高统一本体”的操作，都必须证明多个本体对同一 present slice 的 lineage reconstruction 存在充分收敛。
+
+---
+
+## 14. Agent Federation：大规模 agent 在 v13 中如何分工
+
+### 14.1 Provenance Tracer Agents
+
+负责：
+
+- 从 present slice 往回构造 near/mid/deep lineage
+- 生成 minimal sufficient provenance 候选
+
+### 14.2 Pruned Branch Archivists
+
+负责：
+
+- 找历史失败分支
+- 归档被剪掉的 possibility regions
+- 评估重新激活风险
+
+### 14.3 Branch Planner Agents
+
+负责：
+
+- 在 lineage 上找 branch point
+- 设计 future branch
+- 评估风险与信息增益
+
+### 14.4 Lineage Convergence Auditors
+
+负责：
+
+- 比较不同 ontology 对同一 present slice 的 lineage reconstruction
+- 审核 convergence / divergence / incommensurability
+
+### 14.5 Compile Council
+
+负责：
+
+- 决定哪条 lineage 可以进入 civilization memory
+- 防止无 lineage 的静态解释进入 compiled world model
+
+### 14.6 一条核心纪律
+
+> **因为 candidate lineage 可以无限生成，所以进入 compiled memory 的 lineage 必须经过更严格的最小充分性、反例、剪枝边界和分叉治理审理。**
+
+---
+
+## 15. 典型例子：v13 如何理解“数据库连接超时”
+
+普通系统会问：
+
+- 根因是什么
+- 下一步查什么
+
+v13 会先问：
+
+- 这个 timeout 是当前哪一个 PresentSlice
+- 它来自怎样的 near/mid/deep lineage
+- 哪些历史 failure boundary 已经定义了今天的 topology / policy / SG design
+- 当前这个现态，是不是某条 retired failure 被重新激活
+- 未来应该在哪个 branch point 上干预，而不是只在现态上补洞
+
+于是最后写入的不只是：
+
+> “安全组缺失导致 5432 timeout”
+
+而是：
+
+- 当前 timeout 是怎样由 topology + deployment history + SG policy drift 压缩出来的
+- 哪个历史边界曾经阻止此类故障反复出现
+- 这次为什么又重新打开
+- 最值得干预的 branch point 是哪里
+- 哪些 future branches 值得继续监测
+
+这时，“理解问题”才真正变成“还原来源，从而知道往哪里走”。
+
+---
+
+## 16. v13 的最终主张
+
+因为不存在一个没有历史的当下，所以知识系统不能再以“静态事实库”为中心。  
+因为理解一个问题，本质上是还原它的来源，所以解释必须变成 provenance reconstruction。  
+因为未来不是从零出现，而是从来源链上分叉，所以规划必须变成 branch governance。  
+因为统一整体不能先验假设，所以全局统一只能在 lineage convergence 下逐步证明。
+
+因此，v13 的最终定义是：
+
+> **一个保存当前状态如何由历史生成、保存哪些可能性已被剪掉、保存未来还能从哪里分叉，并据此持续完善本体边界的历史生成本体引擎。**
+
+再压成最狠的一句：
+
+> **系统不再优先问“它是什么”，而优先问“它是怎样变成现在这样的，以及现在还能往哪里分叉”。**
+
+---
+
+## 17. 文件命名建议
+
+主文件名建议：
+
+```text
+v13_historical_generative_ontology.md
+```
+
+可选拆分文件：
+
+```text
+v13_lineage_schema.md
+v13_branch_governance.md
+v13_failure_boundary_archive.md
+v13_lineage_compile_protocol.md
+```

--- a/docs/review/review-2026-04-15-v13-project-review-kilo-addendum.md
+++ b/docs/review/review-2026-04-15-v13-project-review-kilo-addendum.md
@@ -1,0 +1,91 @@
+---
+kind: record
+event: "2026-04-15 v13 project review kilo addendum"
+recorded_at: 2026-04-15
+immutable: true
+---
+
+# Kilo Audit Addendum
+
+Scope: skeptical re-audit of `review-2026-04-15-v13-project-review.md` against the current workspace state.
+
+Verification run in this turn:
+
+- `npm run build` in `causal-learner/mcp-server` completed successfully (`tsc`).
+- `npm test` in `causal-learner/mcp-server` completed successfully with `231` passing tests and `0` failures.
+- The passing test run still emitted repeated `recordFix.constitutionalAudit best-effort` warnings, including failed mandatory constraints (`CC_has_premises`, `CC_has_conclusion`).
+
+## FAILURES
+
+- The prior review overstated `HIGH 3`. `FailureBoundaryArchive` and `CounterexampleCommons` are not absent from current reality. Evidence exists in current docs and code:
+  - `docs/current/testing-roadmap-v7-to-v11.md:21` explicitly says v11 has partially absorbed objects and passing tests.
+  - `causal-learner/mcp-server/src/core/pipeline.ts:1042-1075` writes `FailureBoundaryArchive` records during `recordFix`.
+  - `causal-learner/mcp-server/src/core/failure-boundary-archive-store.ts:23-72` and `causal-learner/mcp-server/src/core/counterexample-commons.ts:42-156` implement the objects.
+  - The correct claim is narrower: these assets exist, but they are not the operating center and are not yet closed into full v13 lineage governance.
+
+- “HIGH 4 fixed” and “MEDIUM 6/7 fixed” appear in code comments, but those labels are not proof. They only show that new files were added:
+  - `causal-learner/mcp-server/src/core/pipeline.ts:921`
+  - `causal-learner/mcp-server/src/core/pipeline.ts:937`
+  The implementation still needs contract alignment and dedicated verification.
+
+## SKIPPED STEPS
+
+- No `.kilocode/**/*.md` rules were available to inspect. The workspace contains `.kilo/plans/1776263856507-mighty-otter.md`, but `rg --files .kilocode` returned no files. Any claim that `.kilocode` instructions were followed would be uncheckable.
+
+- No direct tests were found for the new governance persistence surfaces:
+  - `rg -n "reconstruction-store|branch-point|BranchPoint|FutureBranch|reconstructions|branchPoints" causal-learner/mcp-server/src/tests` returned no matches.
+  This means the new `ReconstructionStore`, `BranchPoint`, and `BranchPointStore` paths are only indirectly covered, if at all.
+
+- No current contract was found for `BranchPoint` / `FutureBranch` / `ReconstructionStore` in `docs/current`.
+  - `rg -n "branch-point|BranchPoint|FutureBranch|reconstruction-store|ReconstructionStore" docs/current` returned no matches.
+  The new code is wired directly against design-history text, not a current contract surface.
+
+## UNVERIFIED CLAIMS
+
+- Before this addendum, any statement such as “tests pass” or “the fix is done” was unverified in this turn. The review relied on repository documents, not fresh command output.
+
+- Passing tests do not prove constitutional enforcement. The current test run passed while still printing multiple warnings like:
+  - `recordFix.constitutionalAudit best-effort failure`
+  - failed mandatory constraints `CC_has_premises`
+  - failed mandatory constraints `CC_has_conclusion`
+  This means “the suite is green” is not enough to claim governance correctness.
+
+## INCOMPLETE WORK
+
+- Mandatory constitutional audit failures do not block `recordFix`.
+  - `docs/current/v11-world-model-contract.md:60-85` defines mandatory constitutional constraints as required.
+  - `causal-learner/mcp-server/src/core/pipeline.ts:923-934` audits the trace, but when `mandatoryPassed` is false it only calls `warnBestEffortFailure(...)` and continues.
+  - This is a real semantic gap: mandatory constraints are treated as advisory warnings in the main pipeline path.
+
+- The new branch-governance objects are reduced surrogates, not faithful v13 implementations.
+  - v13 design requires:
+    - `BranchPoint { lineageId, locationDescription, controllableFactors, uncontrollableFactors, historicalSensitivity }`
+    - `FutureBranch { interventionIds, predictedTrajectory, predictedOutcomes, riskProfile[], informationGainEstimate? }`
+    - Source: `docs/design_history/v13_historical_generative_ontology.md:394-414`
+  - Current implementation provides:
+    - `BranchPoint { episodeId, candidateCount, chosenBranchId, ... }`
+    - `FutureBranch { pathAtomIds, predictedOutcome, riskProfile: string, score, status, pruneReason }`
+    - Source: `causal-learner/mcp-server/src/core/branch-point.ts:17-92`
+  - This is a simplified approximation. It does not yet carry lineage identity, historical sensitivity, intervention identity, predicted trajectory structure, or information-gain semantics.
+
+- v13 compile-governance closure is still incomplete even after the new files landed.
+  - No `LineageCompileProposal`, `HistoricalCompressionRecord`, `LineageConvergenceRecord`, or `PresentSlice` implementation exists in current code or current contracts.
+  - `rg -n "LineageCompileProposal|HistoricalCompressionRecord|LineageConvergenceRecord|PresentSlice" docs/current causal-learner/mcp-server/src` returned no matches.
+
+## VIOLATIONS
+
+- Under the requested Kilo rule set, the English-only documentation/comments rule is currently violated by multiple active files:
+  - `docs/review/review-2026-04-15-v13-project-review.md`
+  - `docs/current/testing-roadmap-v7-to-v11.md:6-21`
+  - `.kilo/plans/1776263856507-mighty-otter.md:1-10`
+  - `causal-learner/mcp-server/src/core/pipeline.ts:360-368` and many later inline comments
+
+- Under the same rule set, the codebase still uses in-memory defaults (`:memory:`) throughout pipeline storage configuration:
+  - `causal-learner/mcp-server/src/core/pipeline.ts:376-405`
+  This is not automatically wrong for tests, but it means no one should claim “absolutely no in-memory patterns” are currently enforced in the implementation.
+
+## Bottom Line
+
+- Show-me-the-logs verdict: build and tests were actually run in this turn, and both succeeded.
+- Show-me-the-semantics verdict: governance is not “done”. The suite is green while mandatory constitutional failures are tolerated, branch governance is a reduced surrogate, and the current-contract layer still lags behind the code.
+- This addendum supersedes the prior review wherever that review claimed v11 failure-memory objects were absent rather than partially absorbed.

--- a/docs/review/review-2026-04-15-v13-project-review.md
+++ b/docs/review/review-2026-04-15-v13-project-review.md
@@ -1,0 +1,351 @@
+---
+kind: record
+event: "2026-04-15 v13 project review"
+recorded_at: 2026-04-15
+immutable: true
+---
+
+# 基于 v13 的当前项目评审（2026-04-15）
+
+> 目的：以 `docs/design_history/v13_historical_generative_ontology.md` 为参照，判断 BestQ-A 当前主线距离“历史生成本体引擎”还有多远，并明确哪些能力已具备、哪些仍只是设计史或 draft。
+
+---
+
+## Findings
+
+### HIGH 1. 当前项目的语义中心仍不是 v13 的 lineage-centered 主线
+
+当前正式语义底座仍然是五模块并列：
+
+```text
+ProblemClass / Strategy / Skill / Story / Atom-Ref-Shortcut
+```
+
+证据：
+
+- `docs/current/metamodel.md:17` 明确写的是“五个并列模块”
+- `docs/current/metamodel.md:13` 明确说明当前语义底座“不是 v6，而是 v1-v5 的收束”
+- `docs/current/metamodel.md:375` 明确当前关键运行路径是
+  `classify -> contextualize -> constrain subgraph -> explore`
+
+这套中心是：
+
+- 问题归类
+- 子图约束
+- 路径搜索
+- Skill 执行
+- Story 驱动 compile
+
+它并不是 v13 所要求的：
+
+- `PresentSlice`
+- `ProvenanceLineage`
+- `near / mid / deep cause`
+- `minimalityJustification`
+- `pruned branch refs`
+- `branch point governance`
+
+结论：
+
+> 当前项目已经不是“普通检索系统”，但也还不是 v13 所定义的“把当前状态当作历史压缩态来治理”的系统。
+
+### HIGH 1b. v13 所需对象在运行层已实现，但 current 合同仍停在 draft 阶段说明
+
+目前 `CounterfactualScenario` 与 `ExperimentDesign` 已从“缺失”变成“可运行对象 + 可持久化 + 主线闭环”，但当前合同仍写作“无显式对象 / 未实现”。
+
+证据：
+
+- `causal-learner/mcp-server/src/core/counterfactual-scenario.ts:36-59` 定义了 `CounterfactualScenario`，`66-77` 有构造输入不变量，`91-175` 有推演入口 `inferCounterfactual`。
+- `causal-learner/mcp-server/src/core/experiment-design.ts:15-42` 定义了 `ExperimentDesign`，`143-194` 包含构造器与闭环计算。
+- `causal-learner/mcp-server/src/core/counterfactual-scenario-store.ts:66-106` 与 `causal-learner/mcp-server/src/core/experiment-design-store.ts:66-106` 提供持久化能力。
+- `causal-learner/mcp-server/src/core/pipeline.ts:66-69,149-152,417-419,1062-1138` 将二者接入 pipeline 并实现 `executeExperimentDesign`（Scenario→Design→Execution）。
+- 对应合同却仍是旧判断：`docs/current/counterfactual-scenario-contract.md:186-190`、`docs/current/experiment-design-contract.md:163-170`。
+
+结论：
+
+> 这是实现进度与合同基线不一致的高风险点：决策层可能继续把已落地功能当作“未做”，误判优先级与治理范围。
+
+---
+
+### HIGH 2. 当前 compile 仍以路径强化为中心，不是最小充分追溯
+
+`compile` 的当前合同仍然是：
+
+- 对 `correctPath` 强化
+- 对 `failedPath` 削弱
+- 对 compiled ref 追加 Evidence
+- 视情况创建 Shortcut
+
+证据：
+
+- `docs/current/compile-promotion-contract.md:37` 开始定义的是“对 correctPath 强化”
+- `docs/current/compile-promotion-contract.md:42` 明确 `weight = min(1.0, weight + 0.1)`
+- `docs/current/compile-promotion-contract.md:104` 开始强调的是 Evidence 追加顺序
+
+与此同时，当前“重建”的核心对象仍是 `AcceptedReconstruction`，其硬要求是：
+
+- 必须有 `reconstructed_timeline`
+- 必须有 `fidelity`
+
+证据：
+
+- `docs/current/reconstruction-contract.md:13` 明确“没有 AcceptedReconstruction，系统只有 retrieval，没有过程重建”
+- `docs/current/reconstruction-contract.md:35` 明确“只有 ID 列表没有过程链的输出不是 Reconstruction”
+- `docs/current/reconstruction-contract.md:42` 起定义 `AcceptedReconstruction`
+
+这说明项目目前能做的是：
+
+- 过程重建
+- 机制链校验
+- fidelity 审计
+
+但还不能稳定表达 v13 所要求的：
+
+- 为什么这条 lineage 已经“足够”
+- 为什么无需继续深挖
+- unresolved gaps 在哪里
+- 这个 present slice 压缩了哪些失败边界与历史分支
+
+结论：
+
+> 当前系统已经进入“过程重建”阶段，但还没有进入“最小充分来源追溯”阶段。
+
+### MEDIUM 6. compile 与 v13 的分叉治理闭环仍不对齐
+
+`compile` 目前主要是对 correctPath 的权重与 mode 调整（含 failedPath 削弱），并未形成 v13 要求的 `LineageCompileProposal`、`pruned branch` 及分叉治理绑定。
+
+证据：
+
+- `causal-learner/mcp-server/src/core/atom-graph.ts:981-981` 的 compile 实现只在 `correctPath` 与 `failedPath` 上做权重/模式更新，未产出 lineage proposal 对象。
+- `causal-learner/mcp-server/src/core/pipeline.ts:670-717` 里 compile 通过 Hypothesis 门控后直接进行支持证据补强与机制实例/重建创建。
+- `docs/design_history/v13_historical_generative_ontology.md:520-563` 要求 `LineageCompileProposal`、`PrunedBranchRecord`、`HistoricalCompressionRecord`，但当前仓内未见对应可持久对象类型。
+
+结论：
+
+> 代码在 v13 的最小充分追溯字段上有进展，但编译闭环仍停在路径权重优化层，尚未形成分叉治理主线。
+
+### HIGH 4. v13 的 provenance reconstruction 虽能生成，但不是可治理的持久对象
+
+`AcceptedReconstruction` 已具备 v13 过渡字段（`nearCauseSegment/midCauseSegment/deepCauseSegment`、`minimalityJustification`、`unresolvedGaps`），但它现在不是一等、可持久检索的治理对象。
+
+证据：
+
+- `docs/design_history/v13_historical_generative_ontology.md:318-359` 定义了 `PresentSlice` 与 `ProvenanceLineage`，要求先验解释必须由 `provenance` 对象承载。
+- `causal-learner/mcp-server/src/core/reconstruction.ts:79-110` 在 `AcceptedReconstruction` 中实现了 v13 字段雏形。
+- `causal-learner/mcp-server/src/core/pipeline.ts:799-891`、`1002` 仅在 `recordFix` 里创建对象并将 `acceptedReconstructionId` 写入 `Episode`，没有 `save` 到任何 reconstruction store。
+- `rg -n "AcceptedReconstructionStore|reconstruction store|ReconstructionStore" causal-learner/mcp-server/src` 仅命中 `pipeline.ts:1002` 与 `story.ts:114`，说明缺少持久化对象仓。
+- `causal-learner/mcp-server/src/core/derivation-trace-store.ts` 保存的是 `reconstruction_id` 的索引和 trace 本体，但没有反查本体的 `AcceptedReconstruction` 内容。
+
+结论：
+
+> 当前只建立了“可返回的重建快照”，未建立 compile council 可直接 audit 的 lineage archive（对象可被查询、对比、复用）。  
+
+### MEDIUM 7. 未来规划未形成 branch-point 治理对象链
+
+v13 要求未来预测要回指 `BranchPoint` 并输出 `FutureBranch` 及风险治理，但执行环路仍是单步动作闭环，缺少分叉对象。
+
+证据：
+
+- `docs/design_history/v13_historical_generative_ontology.md:391-415` 明确 `BranchPoint` 与 `FutureBranch` 的契约接口与分叉治理目标。
+- `causal-learner/mcp-server/src/core/pipeline.ts:1094-1214` 的 `executeExperimentDesign` 仍是 `ExperimentDesign.recommendedAction -> ActionExecution -> new Episode`。
+- `causal-learner/mcp-server/src/core/pipeline.ts:1251-1264` 的返回值仅有 `design / execution / outcomeRecord / predictionError / programRevisionProposal`，无 branch point / branch governance 字段。
+- `rg -n "branchPoint|FutureBranch|branchGovernance|informationGain" causal-learner/mcp-server/src` 无命中任何实现对象。
+
+结论：
+
+> 该路径可以落地“执行建议”，但不能支持“在哪个分支点激活、哪条 future branch 保留、何时剪枝回退”的治理语义。
+
+---
+
+### HIGH 3. v13 的 failure / pruned-branch / historical compression 资产还不存在于当前主线上
+
+当前真实存在的记忆层，在 Phase 1 里只有 `regulation_store`。
+
+证据：
+
+- `docs/current/memory-layer-current.md:12` 明确写“唯一落地的存储层 regulation_store”
+- `docs/current/memory-layer-current.md:22` 明确 `regulation_store` 的职责是因果规则状态机
+- `docs/current/memory-layer-current.md:26` 明确禁止在 Phase 1 代码里引用 `case_memory / lesson_ledger / knowledge_index / SimpleMem`
+
+而 v13 要求的重要上层资产，例如：
+
+- `FailureBoundaryArchive`
+- `CounterexampleCommons`
+- `HistoricalCompressionRecord`
+- `PrunedBranchRecord`
+
+在当前仓内并未进入 current 主线。
+
+证据：
+
+- `docs/current/civilization-memory-contract.md:3` 是 `status: draft`
+- `docs/current/civilization-memory-contract.md:26` 开始定义 `FailureBoundaryArchive / CounterexampleCommons`
+- `docs/design_history/current-boundary-map.md:18` 仍把 v11 视为 horizon layer
+- `docs/design_history/current-boundary-map.md:32` 明确 `v9-v11 layers` 仍是 deferred
+- `rg -n "PresentSlice|ProvenanceLineage|PrunedBranchRecord|HistoricalCompressionRecord|LineageConvergenceRecord|LineageCompileProposal|BranchPoint|FutureBranch" docs/current causal-learner/mcp-server/src` 未命中上述 v13 关键对象（未落库）。
+
+这意味着：
+
+- 失败边界还不是当前可编译资产
+- “被剪掉的真实分支”还没有显式对象
+- “这个当下究竟压缩了哪些历史”还没有稳定记忆对象
+
+结论：
+
+> 以 v13 标准看，当前项目的“失败知识”还停留在 draft / 北极星层，没有进入日常运行与 compile 治理。
+
+---
+
+### MEDIUM 4. 当前已经出现制度化修正链，但未来治理仍不是 lineage branch governance
+
+当前项目已经具备一条比较成熟的制度化修正链：
+
+```text
+PredictionError
+  -> ProgramRevisionProposal
+  -> ReviewDecision
+  -> OntologyDelta
+```
+
+证据：
+
+- `docs/current/program-revision-proposal-contract.md:16` 开始定义 `ProgramRevisionProposal`
+- `docs/current/program-revision-proposal-contract.md:46` 明确链条 `PredictionError -> ProgramRevisionProposal`
+- `docs/current/review-decision-contract.md:15` 开始定义 `ReviewDecision`
+- `docs/current/review-decision-contract.md:47` 明确链条
+  `ProgramRevisionProposal -> ReviewDecision -> OntologyDelta`
+- `docs/current/review-decision-contract.md:113` 到 `:116` 显示该对象已转 current 且已验证三态
+
+这是当前项目很强的一点，因为它已经不只是“直接改模型”，而是有了 proposal 和审查裁决层。
+
+但从 v13 角度看，这仍然主要是在治理：
+
+- 偏差如何导致模型修正
+- 哪条 proposal 被接受/拒绝/取代
+
+还不是在治理：
+
+- 这条 lineage 上的哪个 branch point 值得干预
+- 哪个 future branch 应激活
+- 哪个 pruned branch 必须持续守住
+
+相关未来对象目前仍未实现：
+
+- `docs/current/counterfactual-scenario-contract.md:191` 明确 `CounterfactualScenario` “无显式对象 / 未实现”
+- `docs/current/experiment-design-contract.md:168` 明确 `ExperimentDesign` “无显式对象 / 未实现”
+
+结论：
+
+> 当前项目已经有“制度化修正治理”，但还没有进入 v13 的“基于来源链的未来分叉治理”。
+
+---
+
+### MEDIUM 5. 项目的边界叙述已经部分落后于仓内现实
+
+当前仓内已经有一部分 v10 向主线渗透的事实：
+
+- `ObservationModel` 已把 `observerModelRef / instrumentModelRef` 纳入合同
+- 新 ObservationRecord 在当前主线下必须带 `observationModelId`
+- 仓内已有 `ObserverModel` 类型、store 和测试
+
+证据：
+
+- `docs/current/observation-model-contract.md:90` 与 `:91` 已出现 `observerModelRef / instrumentModelRef`
+- `docs/current/observation-model-contract.md:145` 到 `:149` 明确当前主线下新生成的 `ObservationRecord` 必须带 `observationModelId`
+- `causal-learner/mcp-server/src/core/observer-model.ts:28` 已定义 `ObserverModel`
+- `causal-learner/mcp-server/src/core/observer-model-store.ts:38` 已创建 `observer_models` 表
+- `causal-learner/mcp-server/src/tests/v10-participatory-world.test.ts:120` 已有 `filterObservations` 测试
+
+但与此同时，当前边界描述仍保留“v10 零代码实现”的判断：
+
+- `docs/current/testing-roadmap-v7-to-v11.md:15` 仍写 v10 是“零代码实现”
+- `docs/design_history/current-boundary-map.md:17` 仍用该路线图支撑 v10 deferred 判断
+
+这不代表项目已经主线化 v10；更准确的判断应是：
+
+- v10 还没有成为 operating center
+- 但它已经不是“零代码”
+- 它至少已经以 `ObservationModel + ObserverModel` 的局部形式进入现实边界
+
+结论：
+
+> 当前仓库最大的即时治理问题，不是“是否已经是 v13”，而是“边界地图和真实实现开始出现轻度偏差”。
+
+---
+
+## 总判断
+
+### 一句话结论
+
+**BestQ-A 当前还不能被准确描述为 v13 历史生成本体引擎。**
+
+更准确的表述是：
+
+> 当前主线仍然是  
+> `v6 lawful kernel + current metamodel semantic base + v7 reconstruction backbone + selective v8 absorption`，  
+> 而不是 `v13 lineage-centered historical generative ontology`。
+
+这与当前 boundary map 的主判断基本一致：
+
+- `docs/design_history/current-boundary-map.md:19`
+- `docs/design_history/current-boundary-map.md:21`
+- `docs/design_history/current-boundary-map.md:22`
+
+---
+
+## 已有可继承资产
+
+虽然当前不是 v13 主线，但并不是“离得很远、要推倒重来”。相反，仓里已经有几块对 v13 很关键的前置资产：
+
+1. `AcceptedReconstruction + fidelity`
+   这是从“检索”进入“过程重建”的硬前置。
+
+2. `ObservationModel + ObserverModel`
+   这是从“观测事实”进入“带位置的观测投影”的硬前置。
+
+3. `PredictionError -> ProgramRevisionProposal -> ReviewDecision -> OntologyDelta`
+   这是从“发现偏差”进入“制度化更新裁决”的硬前置。
+
+4. `current-boundary-map.md`
+   这是当前仓最重要的解释器之一，能防止设计史直接压扁当前主线。
+
+---
+
+## 最小迁移建议
+
+如果要让项目朝 v13 演进，最小值路径不应是直接把 v13 整体主线化，而应先补三个桥接对象：
+
+1. `PresentSlice`
+   用来替代当前“Episode/Observation 的局部解释面”。
+
+2. `AcceptedProvenanceReconstruction`
+   在 `AcceptedReconstruction` 之上补
+   `near/mid/deep cause + minimalityJustification + unresolvedGaps`。
+
+3. `PrunedBranchRecord`
+   先把失败边界从“抽象文明资产”下沉成“当前可引用的被剪掉分支记录”。
+
+这三者都比直接引入整套 `Civilization Memory Layer` 更稳，也更符合仓内“先 current，再 horizon”的治理纪律。
+
+---
+
+## Open Questions
+
+1. `AcceptedReconstruction` 是否准备继续扩成 provenance reconstruction，而不是另起一套平行对象？
+2. `FailureBoundaryArchive` 是否应先拆成更小的 current 对象，例如 `PrunedBranchRecord`，再逐步汇总成 archive？
+3. `current-boundary-map.md` 是否应该修订为“v10 局部吸收已发生，但未成为 operating center”，以避免继续用“零代码”误导下游判断？
+
+---
+
+## Review Basis
+
+本次评审基于：
+
+- `docs/design_history/v13_historical_generative_ontology.md`
+- `docs/current/*` 当前合同
+- `docs/design_history/current-boundary-map.md`
+- `docs/review/review-2026-04-14-v8-v11-positioning.md`
+- `causal-learner/mcp-server/src/core/observer-model*.ts`
+- `causal-learner/mcp-server/src/tests/v10-participatory-world.test.ts`
+
+本次未重新跑测试；判断依据是合同、边界文档、代码存在性与测试文件存在性的交叉核对。


### PR DESCRIPTION
## Summary

- **Event 证据链**：Regulation 新增 `confirmedByEvents[]` / `challengedByEvents[]`，所有知识必须可追溯到观测事件
- **diagnose_problem + update_diagnosis**：工具定义和 handler 被意外注释为单行注释，本 PR 解注释并暴露两个 MCP 工具
- **suggestCauses 两处 bug 修复**：
  - `matchedPredicates` 始终为空（eff 命中不记录到数组）
  - `confidence` 阈值过保守：改用 `effMatchRatio`（eff 覆盖比例）替代稀释后的 `overlapScore/totalFields`
- **docs**：v13 历史生成本体设计记录 + Kilo 审计报告

## Test plan

- [x] 诊断推理 e2e 7/7 通过（Phase 1-7：种子→归纳→不完整诊断→补充诊断→converge）
- [x] 全量 211/211 无回归
- [x] 手动 MCP 验证：T3 返回信息缺口标注，T4 ConfigError 分数翻倍且排名第一

🤖 Generated with [Claude Code](https://claude.com/claude-code)