### PR TITLE
feat: 暴露知识组合引擎为 MCP 工具 (#77)

### DIFF
--- a/artifacts/contract-audit-latest.json
+++ b/artifacts/contract-audit-latest.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-04-15T15:34:13.325Z",
-  "files_scanned": 709,
+  "timestamp": "2026-04-16T13:30:58.092Z",
+  "files_scanned": 711,
   "errors": [],
   "warnings": [
     {
@@ -37,6 +37,13 @@
       "code": "duplicate-truth",
       "level": "warning",
       "msg": "describes 与 docs/current/transition-contract.md 相似（Jaccard=0.60）"
+    },
+    {
+      "file": "docs/current/branch-point-contract.md",
+      "line": 1,
+      "code": "missing-schema-version",
+      "level": "warning",
+      "msg": "kind: contract 建议有 `schema_version:` 字段（int）"
     },
     {
       "file": "docs/current/civilization-memory-contract.md",
@@ -149,6 +156,13 @@
       "code": "describes-too-long",
       "level": "warning",
       "msg": "describes 超过 20 字：27 字"
+    },
+    {
+      "file": "docs/current/reconstruction-store-contract.md",
+      "line": 1,
+      "code": "missing-schema-version",
+      "level": "warning",
+      "msg": "kind: contract 建议有 `schema_version:` 字段（int）"
     },
     {
       "file": "docs/current/review-decision-contract.md",
@@ -265,11 +279,11 @@
   ],
   "summary": {
     "ok": 694,
-    "warn": 15,
+    "warn": 17,
     "err": 0
   },
   "kind_distribution": {
-    "contract": 52,
+    "contract": 54,
     "instance": 641,
     "record": 2,
     "code": 12,
@@ -293,7 +307,10 @@
     "missing_implements": [],
     "bad_implements_target": [],
     "implements_wrong_kind": [],
-    "missing_schema_version": [],
+    "missing_schema_version": [
+      "docs/current/branch-point-contract.md",
+      "docs/current/reconstruction-store-contract.md"
+    ],
     "bad_mechanism_instance_ref": [],
     "bad_ontology_delta_ref": [],
     "trace_reconstruction_mismatch": [],
@@ -372,6 +389,11 @@
       "file": "docs/current/artifact-contract.md",
       "kind": "contract",
       "density": 0.069
+    },
+    {
+      "file": "docs/current/branch-point-contract.md",
+      "kind": "contract",
+      "density": 0.0292
     },
     {
       "file": "docs/current/civilization-memory-contract.md",
@@ -542,6 +564,11 @@
       "file": "docs/current/reconstruction-contract.md",
       "kind": "contract",
       "density": 0.0454
+    },
+    {
+      "file": "docs/current/reconstruction-store-contract.md",
+      "kind": "contract",
+      "density": 0.063
     },
     {
       "file": "docs/current/ref-algebra-contract.md",
@@ -7843,6 +7870,17 @@
       "warnings": 0
     },
     {
+      "file": "docs/current/branch-point-contract.md",
+      "format": "md",
+      "status": "current",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "BranchPointStore",
+      "density": 0.0292,
+      "errors": 0,
+      "warnings": 1
+    },
+    {
       "file": "docs/current/civilization-memory-contract.md",
       "format": "md",
       "status": "draft",
@@ -8215,6 +8253,17 @@
       "density": 0.0454,
       "errors": 0,
       "warnings": 0
+    },
+    {
+      "file": "docs/current/reconstruction-store-contract.md",
+      "format": "md",
+      "status": "current",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "ReconstructionStore",
+      "density": 0.063,
+      "errors": 0,
+      "warnings": 1
     },
     {
       "file": "docs/current/ref-algebra-contract.md",

--- a/causal-learner/mcp-server/src/index.ts
+++ b/causal-learner/mcp-server/src/index.ts
@@ -93,6 +93,15 @@ import { suggestNextExperiment } from './tools/experiment-advisor.js';
 // 诊断推理工具
 import { diagnose, updateDiagnosis } from './tools/diagnostic-reasoning.js';
 
+// 知识组合引擎
+import {
+  discoverCompositions,
+  traceKnowledge,
+  renderKnowledgeTrace,
+  stratifyByTrust,
+  computeTrust,
+} from './core/knowledge-composition.js';
+
 // 自然语言解析工具
 import {
   parseNaturalLanguage,
@@ -762,6 +771,38 @@ const TOOLS: Tool[] = [
       required: ['previousFacts', 'newFacts'],
     },
   },
+  // 知识组合引擎工具
+  {
+    name: 'discover_compositions',
+    description: 'Scan all regulations and automatically discover chain/condition compositions. Returns newly derived regulations (not yet in storage). Optionally saves them.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        maxNew: { type: 'number', description: 'Max new compositions to discover (default 20)' },
+        save: { type: 'boolean', description: 'If true, save discovered regulations to storage (default false)' },
+      },
+    },
+  },
+  {
+    name: 'trace_knowledge',
+    description: 'Trace the knowledge provenance of a regulation back to its axiom sources. Returns a tree showing how high-level theorems derive from base observations.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        regulationId: { type: 'string', description: 'ID of the regulation to trace' },
+        maxDepth: { type: 'number', description: 'Maximum depth to trace (default 10)' },
+      },
+      required: ['regulationId'],
+    },
+  },
+  {
+    name: 'stratify_trust',
+    description: 'Stratify all regulations by computed trust level into axioms (trust>0.8), theorems (0.3-0.8), and hypotheses (<0.3). Shows the knowledge hierarchy.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
 ];
 
 // Generate unique observation ID
@@ -1394,6 +1435,66 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const ctx2 = args?.context as Record<string, unknown> | undefined;
         const result = updateDiagnosis(storage, prevFacts, newFacts, ctx2);
         return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      }
+
+      // 知识组合引擎
+      case 'discover_compositions': {
+        const maxNew = (args?.maxNew as number) ?? 20;
+        const save = (args?.save as boolean) ?? false;
+        const regs = storage.listRegulations({ limit: 1000 }).filter((r: Regulation) => r.status !== 'retired');
+        const discovered = discoverCompositions(regs, maxNew);
+        if (save && discovered.length > 0) {
+          for (const reg of discovered) storage.saveRegulation(reg);
+        }
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              discovered: discovered.length,
+              saved: save ? discovered.length : 0,
+              regulations: discovered.map(r => ({
+                regulationId: r.regulationId,
+                level: r.level,
+                description: r.description,
+                derivedFrom: r.derivedFrom,
+                pre: r.pre.map(f => `${f.pred}=${JSON.stringify(f.value)}`),
+                eff: r.eff.map(f => `${f.pred}=${JSON.stringify(f.value)}`),
+              })),
+            }, null, 2),
+          }],
+        };
+      }
+
+      case 'trace_knowledge': {
+        const regId = args?.regulationId as string;
+        const maxDepth = (args?.maxDepth as number) ?? 10;
+        if (!regId) return { content: [{ type: 'text', text: JSON.stringify({ error: 'regulationId required' }) }], isError: true };
+        const lookup = (id: string) => storage.getRegulation(id) ?? null;
+        const trace = traceKnowledge(regId, lookup, maxDepth);
+        if (!trace) return { content: [{ type: 'text', text: JSON.stringify({ error: `regulation ${regId} not found` }) }], isError: true };
+        const rendered = renderKnowledgeTrace(trace);
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({ trace, rendered }, null, 2),
+          }],
+        };
+      }
+
+      case 'stratify_trust': {
+        const regs = storage.listRegulations({ limit: 1000 }).filter((r: Regulation) => r.status !== 'retired');
+        const { axioms, theorems, hypotheses } = stratifyByTrust(regs);
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              axioms: axioms.map(r => ({ regulationId: r.regulationId, trust: computeTrust(r), description: r.description, level: r.level })),
+              theorems: theorems.map(r => ({ regulationId: r.regulationId, trust: computeTrust(r), description: r.description, level: r.level })),
+              hypotheses: hypotheses.map(r => ({ regulationId: r.regulationId, trust: computeTrust(r), description: r.description, level: r.level })),
+              summary: { axioms: axioms.length, theorems: theorems.length, hypotheses: hypotheses.length },
+            }, null, 2),
+          }],
+        };
       }
 
       // 自然语言解析 + 提交

--- a/causal-learner/mcp-server/src/tests/knowledge-composition.test.ts
+++ b/causal-learner/mcp-server/src/tests/knowledge-composition.test.ts
@@ -9,6 +9,7 @@ import {
   isAxiom, getLevel, canChain, chainCompose,
   canMergeConditions, mergeConditions,
   traceKnowledge, renderKnowledgeTrace, discoverCompositions,
+  computeTrust, stratifyByTrust,
 } from '../core/knowledge-composition.js';
 
 // 构造公理
@@ -148,6 +149,107 @@ describe('知识组合引擎', () => {
     console.log(`\n自动发现 ${discovered.length} 条组合知识:`);
     for (const d of discovered) {
       console.log(`  ${d.description} (level=${d.level})`);
+    }
+  });
+
+  it('computeTrust 消费 confirmedByEvents — 事件证据链提升信任度', () => {
+    const withEvents: Regulation = {
+      ...axiom1,
+      regulationId: 'test_with_events',
+      supportN: 10,
+      confirmedByEvents: ['e1', 'e2', 'e3'],
+      challengedByEvents: [],
+      status: 'confirmed',
+    };
+    const withoutEvents: Regulation = {
+      ...axiom1,
+      regulationId: 'test_without_events',
+      supportN: 3,
+      confirmedByEvents: [],
+      challengedByEvents: [],
+      status: 'confirmed',
+    };
+    const noData: Regulation = {
+      ...axiom1,
+      regulationId: 'test_no_data',
+      supportN: 0,
+      confirmedByEvents: [],
+      challengedByEvents: [],
+      status: 'confirmed',
+    };
+
+    const trustWith = computeTrust(withEvents);
+    const trustWithout = computeTrust(withoutEvents);
+    const trustNone = computeTrust(noData);
+
+    // 事件越多支撑越强，信任度越高
+    assert.ok(trustWith > trustWithout, `有事件证据(${trustWith.toFixed(3)}) 应 > 无事件证据(${trustWithout.toFixed(3)})`);
+    assert.ok(trustWithout > trustNone, `有 support(${trustWithout.toFixed(3)}) 应 > 无数据(${trustNone.toFixed(3)})`);
+    // 无数据退化为最低猜测值 0.05
+    assert.strictEqual(trustNone, 0.05);
+    // 有反例会压低信任度
+    const withChallenge: Regulation = {
+      ...withEvents,
+      regulationId: 'test_with_challenge',
+      challengedByEvents: ['c1', 'c2', 'c3', 'c4', 'c5'],
+    };
+    assert.ok(computeTrust(withChallenge) < trustWith, '有挑战事件应降低信任度');
+
+    console.log(`\ncomputeTrust 结果:`);
+    console.log(`  有事件(support=10, confirmed=3): ${trustWith.toFixed(3)}`);
+    console.log(`  无事件(support=3): ${trustWithout.toFixed(3)}`);
+    console.log(`  无数据(support=0): ${trustNone.toFixed(3)}`);
+    console.log(`  有挑战事件(confirmed=3, challenged=5): ${computeTrust(withChallenge).toFixed(3)}`);
+  });
+
+  it('stratifyByTrust 正确分层', () => {
+    // 高信任度：support 极大 + 大量 confirmedByEvents（需 total>=255 才能 >=0.8）
+    const highTrust: Regulation = {
+      ...axiom1,
+      regulationId: 'high_trust',
+      supportN: 200,
+      confirmedByEvents: Array.from({ length: 100 }, (_, i) => `e${i}`),
+      challengedByEvents: [],
+      status: 'confirmed',
+    };
+    // 中等信任度：axiom1～axiom4 的 supportN=20-50，无 confirmedByEvents → trust ∈ [0.3,0.8)
+    // 低信任度：无数据
+    const zeroTrust: Regulation = {
+      ...axiom1,
+      regulationId: 'zero_trust',
+      supportN: 0,
+      confirmedByEvents: [],
+      challengedByEvents: [],
+      status: 'confirmed',
+    };
+
+    const allRegs = [axiom1, axiom2, axiom3, axiom4, highTrust, zeroTrust];
+    const { axioms, theorems, hypotheses } = stratifyByTrust(allRegs);
+
+    // 总数守恒
+    assert.strictEqual(axioms.length + theorems.length + hypotheses.length, allRegs.length);
+
+    // zeroTrust 信任度=0.05 → hypotheses
+    assert.ok(hypotheses.some(r => r.regulationId === 'zero_trust'), 'zeroTrust 应在 hypotheses');
+
+    // highTrust 信任度应为最高层（axioms 或 theorems 均可接受，取决于样本量阈值）
+    const highTrustVal = computeTrust(highTrust);
+    assert.ok(highTrustVal >= 0.3, `highTrust 信任度 ${highTrustVal.toFixed(3)} 应 >= 0.3`);
+
+    // axiom1～4 有 supportN，信任度 > 0.05 → 不在 hypotheses
+    for (const ax of [axiom1, axiom2, axiom3, axiom4]) {
+      assert.ok(
+        !hypotheses.some(r => r.regulationId === ax.regulationId),
+        `${ax.regulationId} 有 support，不应在 hypotheses`
+      );
+    }
+
+    console.log('\nstratifyByTrust 分层结果:');
+    console.log(`  axioms (trust>=0.8): ${axioms.map(r => r.regulationId).join(', ') || '无'}`);
+    console.log(`  theorems (0.3-0.8): ${theorems.map(r => r.regulationId).join(', ') || '无'}`);
+    console.log(`  hypotheses (<0.3): ${hypotheses.map(r => r.regulationId).join(', ') || '无'}`);
+    for (const r of allRegs) {
+      console.log(`    ${r.regulationId}: trust=${computeTrust(r).toFixed(3)}`);
     }
   });
 });


### PR DESCRIPTION
## Summary

知识组合引擎（axiom→theorem 推导）已在 #73 中实现，但未暴露为 MCP 工具。本 PR 添加三个工具：

- **`discover_compositions`** — 自动发现链式/条件组合，返回派生 regulations（可选 save 写入存储）
- **`trace_knowledge`** — 追溯 regulation 的完整知识来源树，渲染 `[公理]/[L1]` 层级文本
- **`stratify_trust`** — 按动态信任度分层（axioms/theorems/hypotheses），依赖 #76 的 confirmedByEvents

## Test plan

- [x] TypeScript 类型检查通过
- [x] 全量 211/211 无回归
- [ ] MCP 工具发现列表将在下次 session 刷新后可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)