### PR TITLE
docs: PresentSlice + LineageCompileProposal + HistoricalCompressionRecord 合约 (#78)

### DIFF
--- a/artifacts/contract-audit-latest.json
+++ b/artifacts/contract-audit-latest.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-04-16T13:30:58.092Z",
-  "files_scanned": 711,
+  "timestamp": "2026-04-16T13:53:02.239Z",
+  "files_scanned": 714,
   "errors": [],
   "warnings": [
     {
@@ -53,11 +53,25 @@
       "msg": "describes 超过 20 字：54 字"
     },
     {
+      "file": "docs/current/historical-compression-record-contract.md",
+      "line": 1,
+      "code": "describes-too-long",
+      "level": "warning",
+      "msg": "describes 超过 20 字：27 字"
+    },
+    {
       "file": "docs/current/intent-alignment-audit-contract.md",
       "line": 1,
       "code": "describes-too-long",
       "level": "warning",
       "msg": "describes 超过 20 字：27 字"
+    },
+    {
+      "file": "docs/current/lineage-compile-proposal-contract.md",
+      "line": 1,
+      "code": "describes-too-long",
+      "level": "warning",
+      "msg": "describes 超过 20 字：22 字"
     },
     {
       "file": "docs/current/ontology-federation-contract.md",
@@ -278,12 +292,12 @@
     }
   ],
   "summary": {
-    "ok": 694,
-    "warn": 17,
+    "ok": 695,
+    "warn": 19,
     "err": 0
   },
   "kind_distribution": {
-    "contract": 54,
+    "contract": 57,
     "instance": 641,
     "record": 2,
     "code": 12,
@@ -451,6 +465,11 @@
       "density": 0.0297
     },
     {
+      "file": "docs/current/historical-compression-record-contract.md",
+      "kind": "contract",
+      "density": 0.0432
+    },
+    {
       "file": "docs/current/hypothesis-contract.md",
       "kind": "contract",
       "density": 0
@@ -474,6 +493,11 @@
       "file": "docs/current/legacy-scaffolds-contract.md",
       "kind": "contract",
       "density": 0.1053
+    },
+    {
+      "file": "docs/current/lineage-compile-proposal-contract.md",
+      "kind": "contract",
+      "density": 0.043
     },
     {
       "file": "docs/current/mechanism-class-contract.md",
@@ -554,6 +578,11 @@
       "file": "docs/current/prediction-error-contract.md",
       "kind": "contract",
       "density": 0
+    },
+    {
+      "file": "docs/current/present-slice-contract.md",
+      "kind": "contract",
+      "density": 0.0779
     },
     {
       "file": "docs/current/program-revision-proposal-contract.md",
@@ -8002,6 +8031,17 @@
       "warnings": 0
     },
     {
+      "file": "docs/current/historical-compression-record-contract.md",
+      "format": "md",
+      "status": "current",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "HistoricalCompressionRecord",
+      "density": 0.0432,
+      "errors": 0,
+      "warnings": 1
+    },
+    {
       "file": "docs/current/hypothesis-contract.md",
       "format": "md",
       "status": "current",
@@ -8055,6 +8095,17 @@
       "density": 0.1053,
       "errors": 0,
       "warnings": 0
+    },
+    {
+      "file": "docs/current/lineage-compile-proposal-contract.md",
+      "format": "md",
+      "status": "current",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "LineageCompileProposal",
+      "density": 0.043,
+      "errors": 0,
+      "warnings": 1
     },
     {
       "file": "docs/current/mechanism-class-contract.md",
@@ -8231,6 +8282,17 @@
       "density": 0,
       "errors": 0,
       "warnings": 6
+    },
+    {
+      "file": "docs/current/present-slice-contract.md",
+      "format": "md",
+      "status": "current",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "PresentSlice",
+      "density": 0.0779,
+      "errors": 0,
+      "warnings": 0
     },
     {
       "file": "docs/current/program-revision-proposal-contract.md",

--- a/causal-learner/mcp-server/src/tests/v13-present-slice-hcr.test.ts
+++ b/causal-learner/mcp-server/src/tests/v13-present-slice-hcr.test.ts
@@ -1,0 +1,307 @@
+/**
+ * v13 PresentSlice + HistoricalCompressionRecord 直接测试
+ * 覆盖：工厂函数、不变量校验、buildPresentSliceFromPipeline、Store CRUD
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  createPresentSlice,
+  buildPresentSliceFromPipeline,
+} from '../core/present-slice.js';
+import type { CreatePresentSliceInput, PipelineSnapshot } from '../core/present-slice.js';
+import { PresentSliceStore } from '../core/present-slice-store.js';
+
+import {
+  createHistoricalCompressionRecord,
+  assertValidCompressionRecord,
+} from '../core/historical-compression-record.js';
+import type { CreateHistoricalCompressionRecordInput } from '../core/historical-compression-record.js';
+import { HistoricalCompressionRecordStore } from '../core/historical-compression-record-store.js';
+
+// =============================================================================
+// 辅助
+// =============================================================================
+
+function makeSliceInput(overrides?: Partial<CreatePresentSliceInput>): CreatePresentSliceInput {
+  return {
+    name: '测试切片',
+    episodeIds: ['ep_001'],
+    fidelityScore: 0.8,
+    ...overrides,
+  };
+}
+
+function makeHcrInput(overrides?: Partial<CreateHistoricalCompressionRecordInput>): CreateHistoricalCompressionRecordInput {
+  return {
+    name: '测试压缩',
+    sourceEpisodeIds: ['ep_001', 'ep_002'],
+    targetPresentSliceId: 'PS_test',
+    retainedAtomIds: ['atom_1'],
+    discardedAtomIds: ['atom_2', 'atom_3'],
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// PresentSlice
+// =============================================================================
+
+describe('PresentSlice 工厂函数', () => {
+  it('createPresentSlice 正常创建', () => {
+    const s = createPresentSlice(makeSliceInput());
+    assert.ok(s.id.startsWith('PS_'), 'id 应以 PS_ 开头');
+    assert.strictEqual(s.name, '测试切片');
+    assert.deepStrictEqual(s.episodeIds, ['ep_001']);
+    assert.strictEqual(s.fidelityScore, 0.8);
+    // 默认数组为空
+    assert.deepStrictEqual(s.reconstructionIds, []);
+    assert.deepStrictEqual(s.activeRegulationIds, []);
+    assert.deepStrictEqual(s.activeBranchPointIds, []);
+    assert.deepStrictEqual(s.unresolvedUnknowns, []);
+  });
+
+  it('fidelityScore 自动 clamp 到 [0,1]', () => {
+    const tooHigh = createPresentSlice(makeSliceInput({ fidelityScore: 1.5 }));
+    assert.strictEqual(tooHigh.fidelityScore, 1.0);
+
+    const tooLow = createPresentSlice(makeSliceInput({ fidelityScore: -0.5 }));
+    assert.strictEqual(tooLow.fidelityScore, 0.0);
+
+    const nonFinite = createPresentSlice(makeSliceInput({ fidelityScore: NaN }));
+    assert.strictEqual(nonFinite.fidelityScore, 0.0);
+  });
+
+  it('buildPresentSliceFromPipeline 计算 fidelityScore 均值', () => {
+    const snapshot: PipelineSnapshot = {
+      name: 'pipeline-slice',
+      episodeIds: ['ep_001', 'ep_002'],
+      reconstructionIds: ['rc_001', 'rc_002'],
+      reconstructionFidelities: [0.6, 0.8],
+      activeRegulationIds: ['reg_001'],
+      activeBranchPointIds: ['bp_001'],
+    };
+    const s = buildPresentSliceFromPipeline(snapshot);
+    assert.ok(s.id.startsWith('PS_'));
+    assert.strictEqual(s.name, 'pipeline-slice');
+    assert.strictEqual(s.fidelityScore, 0.7); // (0.6 + 0.8) / 2
+    assert.ok(s.compressionSummary.includes('2 个 Episode'));
+    assert.ok(s.compressionSummary.includes('2 个 Reconstruction'));
+    assert.strictEqual(s.createdBy, 'pipeline');
+  });
+
+  it('buildPresentSliceFromPipeline 无 Reconstruction 时 fidelityScore=0', () => {
+    const snapshot: PipelineSnapshot = {
+      name: 'empty-slice',
+      episodeIds: ['ep_001'],
+      reconstructionIds: [],
+      reconstructionFidelities: [],
+      activeRegulationIds: [],
+      activeBranchPointIds: [],
+    };
+    const s = buildPresentSliceFromPipeline(snapshot);
+    assert.strictEqual(s.fidelityScore, 0);
+  });
+});
+
+describe('PresentSliceStore CRUD', () => {
+  it('save + get 往返一致', () => {
+    const store = new PresentSliceStore(':memory:');
+    const s = createPresentSlice(makeSliceInput({
+      activeRegulationIds: ['reg_001'],
+      visibleOutcomes: ['outcome_crash'],
+    }));
+    store.save(s);
+
+    const loaded = store.get(s.id);
+    assert.ok(loaded, 'get 应返回已保存的 slice');
+    assert.strictEqual(loaded!.id, s.id);
+    assert.deepStrictEqual(loaded!.activeRegulationIds, ['reg_001']);
+    assert.deepStrictEqual(loaded!.visibleOutcomes, ['outcome_crash']);
+    store.close();
+  });
+
+  it('get 不存在 ID 返回 null', () => {
+    const store = new PresentSliceStore(':memory:');
+    assert.strictEqual(store.get('PS_not_exist'), null);
+    store.close();
+  });
+
+  it('save 幂等：同 id 重复写入覆盖', () => {
+    const store = new PresentSliceStore(':memory:');
+    const s = createPresentSlice(makeSliceInput({ fidelityScore: 0.5 }));
+    store.save(s);
+    // 更新后重存
+    const updated = { ...s, fidelityScore: 0.9, name: '更新后' };
+    store.save(updated);
+
+    const loaded = store.get(s.id);
+    assert.strictEqual(loaded!.fidelityScore, 0.9);
+    assert.strictEqual(loaded!.name, '更新后');
+    store.close();
+  });
+
+  it('getLowFidelity 返回低于阈值的记录', () => {
+    const store = new PresentSliceStore(':memory:');
+    store.save(createPresentSlice(makeSliceInput({ fidelityScore: 0.3 })));
+    store.save(createPresentSlice(makeSliceInput({ fidelityScore: 0.5 })));
+    store.save(createPresentSlice(makeSliceInput({ fidelityScore: 0.9 })));
+
+    const low = store.getLowFidelity(0.6);
+    assert.strictEqual(low.length, 2, '应返回 fidelity < 0.6 的 2 条');
+    assert.ok(low.every(s => s.fidelityScore < 0.6));
+    store.close();
+  });
+
+  it('getByEpisodeId 精确匹配', () => {
+    const store = new PresentSliceStore(':memory:');
+    store.save(createPresentSlice(makeSliceInput({ episodeIds: ['ep_001', 'ep_002'] })));
+    store.save(createPresentSlice(makeSliceInput({ episodeIds: ['ep_002', 'ep_003'] })));
+    store.save(createPresentSlice(makeSliceInput({ episodeIds: ['ep_999'] })));
+
+    const byEp2 = store.getByEpisodeId('ep_002');
+    assert.strictEqual(byEp2.length, 2, 'ep_002 出现在两条记录中');
+    const byEp1 = store.getByEpisodeId('ep_001');
+    assert.strictEqual(byEp1.length, 1);
+    const byMissing = store.getByEpisodeId('ep_000');
+    assert.strictEqual(byMissing.length, 0);
+    store.close();
+  });
+
+  it('getStats 返回正确计数', () => {
+    const store = new PresentSliceStore(':memory:');
+    store.save(createPresentSlice(makeSliceInput()));
+    store.save(createPresentSlice(makeSliceInput()));
+    const stats = store.getStats();
+    assert.strictEqual(stats.totalCount, 2);
+    store.close();
+  });
+});
+
+// =============================================================================
+// HistoricalCompressionRecord
+// =============================================================================
+
+describe('HistoricalCompressionRecord 工厂函数', () => {
+  it('createHistoricalCompressionRecord 正常创建', () => {
+    const r = createHistoricalCompressionRecord(makeHcrInput());
+    assert.ok(r.id.startsWith('HCR_'), 'id 应以 HCR_ 开头');
+    assert.strictEqual(r.name, '测试压缩');
+    assert.deepStrictEqual(r.sourceEpisodeIds, ['ep_001', 'ep_002']);
+    assert.strictEqual(r.targetPresentSliceId, 'PS_test');
+    assert.deepStrictEqual(r.retainedAtomIds, ['atom_1']);
+    // compressionRatio 自动计算: 2 episodes / 1 retained = 2.0
+    assert.strictEqual(r.compressionRatio, 2.0);
+    assert.strictEqual(r.reversible, false);  // 默认不可逆
+  });
+
+  it('compressionRatio 自动计算：无 retained 时回退到 sourceCount', () => {
+    const r = createHistoricalCompressionRecord(makeHcrInput({
+      retainedAtomIds: [],
+    }));
+    // sourceEpisodeIds.length = 2，retainedAtomIds = [] → ratio = 2
+    assert.strictEqual(r.compressionRatio, 2);
+  });
+
+  it('compressionRatio 可由调用方覆盖', () => {
+    const r = createHistoricalCompressionRecord(makeHcrInput({ compressionRatio: 5.5 }));
+    assert.strictEqual(r.compressionRatio, 5.5);
+  });
+
+  it('不变量 HCR-1：sourceEpisodeIds 为空时抛出', () => {
+    assert.throws(
+      () => createHistoricalCompressionRecord(makeHcrInput({ sourceEpisodeIds: [] })),
+      /sourceEpisodeIds 不能为空/,
+    );
+  });
+
+  it('不变量 HCR-2：compressionRatio <= 0 时抛出', () => {
+    assert.throws(
+      () => createHistoricalCompressionRecord(makeHcrInput({ compressionRatio: 0 })),
+      /compressionRatio 必须 > 0/,
+    );
+    assert.throws(
+      () => createHistoricalCompressionRecord(makeHcrInput({ compressionRatio: -1 })),
+      /compressionRatio 必须 > 0/,
+    );
+  });
+
+  it('assertValidCompressionRecord：对合法对象不抛出', () => {
+    const r = createHistoricalCompressionRecord(makeHcrInput());
+    assert.doesNotThrow(() => assertValidCompressionRecord(r));
+  });
+
+  it('reversible=true 可设置', () => {
+    const r = createHistoricalCompressionRecord(makeHcrInput({
+      reversible: true,
+      lossDescription: '完整保留所有 atom，可逆压缩',
+    }));
+    assert.strictEqual(r.reversible, true);
+    assert.strictEqual(r.lossDescription, '完整保留所有 atom，可逆压缩');
+  });
+});
+
+describe('HistoricalCompressionRecordStore CRUD', () => {
+  it('save + get 往返一致', () => {
+    const store = new HistoricalCompressionRecordStore(':memory:');
+    const r = createHistoricalCompressionRecord(makeHcrInput());
+    store.save(r);
+
+    const loaded = store.get(r.id);
+    assert.ok(loaded, 'get 应返回已保存的记录');
+    assert.strictEqual(loaded!.id, r.id);
+    assert.strictEqual(loaded!.compressionRatio, r.compressionRatio);
+    store.close();
+  });
+
+  it('get 不存在 ID 返回 null', () => {
+    const store = new HistoricalCompressionRecordStore(':memory:');
+    assert.strictEqual(store.get('HCR_not_exist'), null);
+    store.close();
+  });
+
+  it('getByPresentSliceId：一个切片关联多条压缩记录', () => {
+    const store = new HistoricalCompressionRecordStore(':memory:');
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ targetPresentSliceId: 'PS_A' })));
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ targetPresentSliceId: 'PS_A' })));
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ targetPresentSliceId: 'PS_B' })));
+
+    assert.strictEqual(store.getByPresentSliceId('PS_A').length, 2);
+    assert.strictEqual(store.getByPresentSliceId('PS_B').length, 1);
+    assert.strictEqual(store.getByPresentSliceId('PS_C').length, 0);
+    store.close();
+  });
+
+  it('getHighCompression 返回比率 >= 阈值的记录（降序）', () => {
+    const store = new HistoricalCompressionRecordStore(':memory:');
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ compressionRatio: 1.5 })));
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ compressionRatio: 3.0 })));
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ compressionRatio: 5.0 })));
+
+    const high = store.getHighCompression(3.0);
+    assert.strictEqual(high.length, 2, '应返回 ratio >= 3.0 的 2 条');
+    assert.ok(high[0].compressionRatio >= high[1].compressionRatio, '应按降序排列');
+    store.close();
+  });
+
+  it('getReversible 只返回可逆记录', () => {
+    const store = new HistoricalCompressionRecordStore(':memory:');
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ reversible: true })));
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ reversible: true })));
+    store.save(createHistoricalCompressionRecord(makeHcrInput({ reversible: false })));
+
+    const reversible = store.getReversible();
+    assert.strictEqual(reversible.length, 2);
+    assert.ok(reversible.every(r => r.reversible));
+    store.close();
+  });
+
+  it('getStats 返回正确计数', () => {
+    const store = new HistoricalCompressionRecordStore(':memory:');
+    store.save(createHistoricalCompressionRecord(makeHcrInput()));
+    store.save(createHistoricalCompressionRecord(makeHcrInput()));
+    store.save(createHistoricalCompressionRecord(makeHcrInput()));
+    assert.strictEqual(store.getStats().totalCount, 3);
+    store.close();
+  });
+});

--- a/docs/current/historical-compression-record-contract.md
+++ b/docs/current/historical-compression-record-contract.md
@@ -1,0 +1,174 @@
+---
+kind: contract
+status: current
+schema_version: 1
+describes: HistoricalCompressionRecord
+implements:
+  - causal-learner/mcp-server/src/core/historical-compression-record.ts
+  - causal-learner/mcp-server/src/core/historical-compression-record-store.ts
+upstream:
+  - present-slice-contract.md
+---
+
+# HistoricalCompressionRecord 合同：历史压缩审计记录
+
+> v13 §12.1 Civilization Memory Layer 核心审计对象。定义历史压缩操作的记录职责、Schema、不变量、持久化层。
+> 上游依赖：PresentSlice（压缩目标）
+> 关联实现：`core/historical-compression-record.ts`、`core/historical-compression-record-store.ts`
+
+---
+
+## §1 职责
+
+HistoricalCompressionRecord 是"当前态是历史的压缩"这一 v13 根公理 G2 的显式落地对象。每次从历史 Episode 压缩到 PresentSlice 的操作，必须产生一条 HCR，记录：
+
+- 哪些 Episode 被压缩（历史来源）
+- 哪些 Atom 被保留、哪些被丢弃
+- 压缩比是多少
+- 压缩是否可逆
+
+**是什么**：
+- 历史压缩操作的审计记录，与 PresentSlice 1:N 关联（一个切片可由多次压缩产生）
+- 告诉后来者"现在为什么看起来这么自然"、哪些失败已被历史抹平
+- `reversible=true` 意味着可从 `retainedAtomIds` 完整重建原始 Episode
+
+**不是什么**：
+- 不执行压缩操作——压缩逻辑由调用方（pipeline 或工具函数）负责
+- 不负责 Episode 的存储——Episode 由 EpisodeEventStore 管理
+- 不驱动 fidelity 回归检查——HCR 是记录层，不是验证层
+
+---
+
+## §2 Schema
+
+```typescript
+interface HistoricalCompressionRecord {
+  id: string;                      // 格式: "HCR_<random_hex_12>"
+  name: string;                    // 人类可读名称（描述本次压缩操作）
+  sourceEpisodeIds: string[];      // 被压缩的 Episode ID（不变量 HCR-1：非空）
+  targetPresentSliceId: string;    // 压缩结果 PresentSlice ID
+  retainedAtomIds: string[];       // 保留的关键节点 Atom ID
+  discardedAtomIds: string[];      // 被丢弃的节点 Atom ID
+  compressionRatio: number;        // 压缩比 = sourceCount / retainedCount（不变量 HCR-2：> 0）
+  lossDescription: string;         // 压缩损失说明（人类可读）
+  reversible: boolean;             // 是否可从 retainedAtomIds 完整重建
+  createdAt: ISO8601;
+  createdBy: string;               // "system" | "pipeline" | 具体调用方标识
+}
+```
+
+---
+
+## §3 工厂函数
+
+| 函数 | 签名 | 语义 |
+|------|------|------|
+| `createHistoricalCompressionRecord` | `(input: CreateHistoricalCompressionRecordInput) => HistoricalCompressionRecord` | 创建实例，自动计算默认 compressionRatio，校验 HCR-1/HCR-2 |
+| `assertValidCompressionRecord` | `(record: HistoricalCompressionRecord) => void` | 校验 HCR-1/HCR-2，违反时抛出 |
+
+### §3.1 compressionRatio 默认计算规则
+
+```
+若 retainedAtomIds 非空：
+  ratio = sourceEpisodeIds.length / retainedAtomIds.length
+
+若 retainedAtomIds 为空：
+  ratio = sourceEpisodeIds.length（若 > 0），否则 1.0（无压缩）
+```
+
+调用方可通过 `compressionRatio` 字段覆盖自动计算值。
+
+---
+
+## §4 持久化层（HistoricalCompressionRecordStore）
+
+SQLite（better-sqlite3）持久化层，WAL 模式。
+
+### §4.1 存储 Schema
+
+```sql
+CREATE TABLE historical_compression_records (
+  id                       TEXT PRIMARY KEY,
+  name                     TEXT NOT NULL,
+  target_present_slice_id  TEXT NOT NULL,
+  compression_ratio        REAL NOT NULL,
+  reversible               INTEGER NOT NULL,          -- 0/1
+  source_episode_count     INTEGER NOT NULL,
+  created_at               TEXT NOT NULL,
+  data                     TEXT NOT NULL              -- 完整 JSON
+);
+
+CREATE INDEX idx_hcr_slice      ON historical_compression_records (target_present_slice_id);
+CREATE INDEX idx_hcr_ratio      ON historical_compression_records (compression_ratio);
+CREATE INDEX idx_hcr_reversible ON historical_compression_records (reversible);
+```
+
+### §4.2 接口
+
+| 方法 | 签名 | 语义 |
+|------|------|------|
+| `save` | `(record: HistoricalCompressionRecord) => void` | INSERT OR REPLACE，幂等写入 |
+| `get` | `(id: string) => HistoricalCompressionRecord \| null` | 按主键精确查询 |
+| `listAll` | `(limit?: number) => HistoricalCompressionRecord[]` | 全量，默认 limit=100 |
+| `getByPresentSliceId` | `(sliceId: string) => HistoricalCompressionRecord[]` | 按 targetPresentSliceId 查询（一个切片可有多条） |
+| `getBySourceEpisodeId` | `(episodeId: string) => HistoricalCompressionRecord[]` | JSON 子串匹配，返回含该 Episode 的所有压缩记录 |
+| `getHighCompression` | `(threshold: number, limit?: number) => HistoricalCompressionRecord[]` | compressionRatio ≥ threshold（降序），默认 limit=50 |
+| `getReversible` | `(limit?: number) => HistoricalCompressionRecord[]` | 只返回 reversible=true 的记录，默认 limit=50 |
+| `getStats` | `() => HistoricalCompressionRecordStoreStats` | 返回 `{ totalCount }` |
+| `close` | `() => void` | 关闭数据库连接 |
+
+### §4.3 HistoricalCompressionRecordStoreStats
+
+```typescript
+interface HistoricalCompressionRecordStoreStats {
+  totalCount: number;
+}
+```
+
+---
+
+## §5 不变量
+
+| # | 不变量 | 违反时的后果 |
+|---|--------|-------------|
+| HCR-1 | `sourceEpisodeIds` 非空（工厂函数校验） | 压缩无来源，语义无效 |
+| HCR-2 | `compressionRatio` > 0（工厂函数校验） | 压缩比无意义 |
+| HCR-3 | `id` 格式为 `HCR_<hex12>`（PRIMARY KEY 约束） | 主键冲突 |
+| HCR-4 | `save` 幂等：同 id 重复写入覆盖而非报错 | INSERT OR REPLACE 保证 |
+| HCR-5 | `getBySourceEpisodeId` 对 JSON 子串匹配后无二次精确过滤（性能取舍，id 足够唯一） | 极低概率误匹配（可接受） |
+| HCR-6 | 构造时自动创建目录 + 初始化表（若不存在） | 零配置启动 |
+| HCR-7 | WAL 模式开启 | 并发读写安全 |
+
+---
+
+## §6 语义定位（v13 G2）
+
+```
+v13 根公理 G2：当前状态是历史的压缩态
+  ↓
+HistoricalCompressionRecord 实现 G2 的显式记录：
+  sourceEpisodeIds  →  压缩前的历史
+  targetPresentSliceId → 压缩后的当下
+  compressionRatio    → 信息丢失程度量化
+  lossDescription     → 丢弃了什么（文明记忆的"负片"）
+  reversible          → 能否还原（可逆性保证）
+```
+
+HCR 是 v13 "文明记忆层（Civilization Memory Layer）"的审计基础：
+后代智能体通过 HCR 可以知道"这种自然感背后，哪些失败已经被历史抹平"。
+
+---
+
+## §7 版本历史
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| 1 | 2026-04-16 | 初版。定义 HistoricalCompressionRecord Schema、工厂函数、HistoricalCompressionRecordStore 持久化层、7 条不变量 |
+
+---
+
+## 参考
+
+- [[present-slice-contract|PresentSlice 合同]] — `targetPresentSliceId` 指向 PresentSlice
+- [[reconstruction-store-contract|ReconstructionStore 合同]] — 姊妹，同为持久化审计层
+- [[branch-point-contract|BranchPoint 合同]] — 分叉治理层，与 HCR 共同支撑 v13 G4

--- a/docs/current/lineage-compile-proposal-contract.md
+++ b/docs/current/lineage-compile-proposal-contract.md
@@ -1,0 +1,202 @@
+---
+kind: contract
+status: current
+schema_version: 1
+describes: LineageCompileProposal
+implements:
+  - causal-learner/mcp-server/src/core/lineage-compile-proposal.ts
+  - causal-learner/mcp-server/src/core/lineage-compile-proposal-store.ts
+upstream:
+  - present-slice-contract.md
+  - compile-promotion-contract.md
+  - review-decision-contract.md
+---
+
+# LineageCompileProposal 合同：谱系编译提案
+
+> v13 §11.1 Institutional Compile Layer 核心对象。定义编译提案的职责、状态机、Schema、不变量、持久化层。
+> 上游依赖：PresentSlice（目标切片）、ReviewDecision（审批决定）
+> 关联实现：`core/lineage-compile-proposal.ts`、`core/lineage-compile-proposal-store.ts`
+
+---
+
+## §1 职责
+
+LineageCompileProposal 是 v13 谱系编译提案对象：记录一次 compile 操作的完整语境，包括为什么这条 lineage 值得编译、有哪些支持证据、有哪些已知反例和剪除分支。
+
+**是什么**：
+- 升级版 CompileProposal——绑定 PresentSlice，使编译操作与"当下是什么"明确关联
+- 状态机驱动：draft → challenged → approved/rejected，approved → applied/rolled_back
+- 记录 `proposedChanges`（Ref 权重变更列表），审批通过后由调用方执行
+
+**不是什么**：
+- 不执行 compile 操作本身——调用方在 `applyProposal` 后负责更新 Ref
+- 不负责 review 决策逻辑——决策由 ReviewDecision 对象承载
+- 不直接操作 AtomGraph——仅记录意图，执行由 pipeline 负责
+
+---
+
+## §2 状态机
+
+```mermaid
+stateDiagram-v2
+  [*] --> draft : createLineageCompileProposal()
+  draft --> challenged : challengeProposal()
+  draft --> approved : approveProposal(reviewDecisionId)
+  draft --> rejected : rejectProposal(reviewDecisionId)
+  challenged --> approved : approveProposal(reviewDecisionId)
+  challenged --> rejected : rejectProposal(reviewDecisionId)
+  approved --> applied : applyProposal()
+  approved --> rolled_back : rollbackProposal()
+```
+
+| 状态 | 语义 | 终态 |
+|------|------|------|
+| `draft` | 提案草稿，待审核 | 否 |
+| `challenged` | 受到质疑，待重新审核 | 否 |
+| `approved` | 审批通过，待执行 | 否 |
+| `rejected` | 审批拒绝 | **是** |
+| `applied` | 已执行 compile | **是** |
+| `rolled_back` | 已回滚 | **是** |
+
+**初始状态固定为 `draft`**：`createLineageCompileProposal` 不接受自定义 status。
+
+---
+
+## §3 Schema
+
+```typescript
+interface LineageCompileProposal {
+  id: string;                          // 格式: "LCP_<random_hex_12>"
+  targetPresentSliceId: string;        // 目标 PresentSlice ID（不变量 LCP-1）
+  proposedLineageId: string;           // 被提议编译的 ProvenanceLineage ID（不变量 LCP-2）
+  supportingEpisodes: string[];        // 支撑 Episode ID（不变量 LCP-3：≥1）
+  counterexampleIds: string[];         // 反例 ID（CounterexampleCommons 条目）
+  prunedBranchRefs: string[];          // 已剪除的分支引用（v13 §11.2 条件 4）
+  branchGovernanceImplications: string[]; // 分叉治理影响说明（v13 §11.2 条件 5）
+  proposedChanges: ProposedRefChange[]; // 提议的 Ref 变更列表
+  justification: string;               // 编译理由（不变量 LCP-4：非空）
+  status: LineageCompileProposalStatus; // 不变量 LCP-5
+  reviewDecisionId: string | null;     // approved/rejected 后填入
+  reconstructionId: string | null;     // 编译依据的 AcceptedReconstruction
+  createdAt: ISO8601;
+  createdBy: string;
+}
+
+interface ProposedRefChange {
+  refId: string;
+  changeKind: 'add' | 'remove' | 'update_weight' | 'update_mode';  // 不变量 LCP-6
+  beforeValue: string | null;    // 新增时为 null
+  afterValue: string | null;     // 删除时为 null
+}
+```
+
+---
+
+## §4 工厂函数与状态转移函数
+
+| 函数 | 签名 | 语义 |
+|------|------|------|
+| `createLineageCompileProposal` | `(input) => LineageCompileProposal` | 创建 draft 提案，自动校验 LCP-1 至 LCP-6 |
+| `challengeProposal` | `(p) => LineageCompileProposal` | draft → challenged |
+| `approveProposal` | `(p, reviewDecisionId) => LineageCompileProposal` | draft/challenged → approved，关联 ReviewDecision |
+| `rejectProposal` | `(p, reviewDecisionId) => LineageCompileProposal` | draft/challenged → rejected，关联 ReviewDecision |
+| `applyProposal` | `(p) => LineageCompileProposal` | approved → applied |
+| `rollbackProposal` | `(p) => LineageCompileProposal` | approved → rolled_back |
+| `transitionProposalStatus` | `(p, target, reviewDecisionId?) => LineageCompileProposal` | 通用状态转移，非法转移抛出异常 |
+
+所有状态转移函数返回**不可变副本**（spread 更新），不修改原对象。
+
+---
+
+## §5 持久化层（LineageCompileProposalStore）
+
+SQLite（better-sqlite3）持久化层，WAL 模式。
+
+### §5.1 存储 Schema
+
+```sql
+CREATE TABLE lineage_compile_proposals (
+  id                       TEXT PRIMARY KEY,
+  target_present_slice_id  TEXT NOT NULL,
+  proposed_lineage_id      TEXT NOT NULL,
+  status                   TEXT NOT NULL,
+  review_decision_id       TEXT,
+  reconstruction_id        TEXT,
+  created_at               TEXT NOT NULL,
+  created_by               TEXT NOT NULL,
+  data                     TEXT NOT NULL          -- 完整 JSON
+);
+
+CREATE INDEX idx_lcp_status  ON lineage_compile_proposals (status);
+CREATE INDEX idx_lcp_slice   ON lineage_compile_proposals (target_present_slice_id);
+CREATE INDEX idx_lcp_lineage ON lineage_compile_proposals (proposed_lineage_id);
+```
+
+### §5.2 接口
+
+| 方法 | 签名 | 语义 |
+|------|------|------|
+| `save` | `(p: LineageCompileProposal) => void` | INSERT OR REPLACE，写入前重新校验不变量 |
+| `get` | `(id: string) => LineageCompileProposal \| null` | 按主键精确查询 |
+| `listByPresentSlice` | `(sliceId: string) => LineageCompileProposal[]` | 按 PresentSlice 查询（created_at ASC） |
+| `listByLineage` | `(lineageId: string) => LineageCompileProposal[]` | 按 lineage ID 查询（created_at ASC） |
+| `listByStatus` | `(status: string, limit?: number) => LineageCompileProposal[]` | 按状态查询（created_at DESC），默认 limit=100 |
+| `listAll` | `(limit?: number) => LineageCompileProposal[]` | 全量（created_at DESC），默认 limit=100 |
+| `getStats` | `() => LineageCompileProposalStoreStats` | 返回 `{ total, byStatus }` |
+| `close` | `() => void` | 关闭数据库连接 |
+
+### §5.3 LineageCompileProposalStoreStats
+
+```typescript
+interface LineageCompileProposalStoreStats {
+  total: number;
+  byStatus: Record<string, number>;   // 各状态的计数
+}
+```
+
+---
+
+## §6 不变量
+
+| # | 不变量 | 违反时的后果 |
+|---|--------|-------------|
+| LCP-1 | `targetPresentSliceId` 非空 | 编译操作失去"当下"锚点 |
+| LCP-2 | `proposedLineageId` 非空 | 编译操作无法关联 lineage |
+| LCP-3 | `supportingEpisodes` 至少一个（v13 §11.2 条件 1） | 无证据支撑的 compile 不合法 |
+| LCP-4 | `justification` 非空 | 编译理由缺失 |
+| LCP-5 | `status` 必须在合法值集合内 | 状态机违反 |
+| LCP-6 | `proposedChanges` 中每条 `changeKind` 合法 | 变更类型未知 |
+| LCP-7 | 状态转移必须遵循许可表 | 非法转移抛出异常 |
+| LCP-8 | `rejected`/`applied`/`rolled_back` 为终态，不可继续转移 | 状态机终态保证 |
+| LCP-9 | `save` 在写入前重新调用 `assertValidLineageCompileProposal` | 持久化层双重校验 |
+
+---
+
+## §7 v13 编译条件对应关系
+
+| v13 §11.2 条件 | 对应字段 |
+|---------------|---------|
+| 1. 有 positioned observations 支持 | `supportingEpisodes` (LCP-3) |
+| 2. 有 replay 或 equivalent reconstruction 支持 | `reconstructionId` |
+| 3. 有最小充分性论证 | `justification` (LCP-4) |
+| 4. 有已知 pruned branches 的引用 | `prunedBranchRefs` |
+| 5. 有对 future branch governance 的说明 | `branchGovernanceImplications` |
+| 6. 若涉及跨本体，必须有 lineage convergence 审理 | 调用方职责，本对象不强制 |
+
+---
+
+## §8 版本历史
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| 1 | 2026-04-16 | 初版。定义 LineageCompileProposal Schema、状态机、6 个状态转移函数、LineageCompileProposalStore、9 条不变量 |
+
+---
+
+## 参考
+
+- [[present-slice-contract|PresentSlice 合同]] — `targetPresentSliceId` 指向 PresentSlice
+- [[compile-promotion-contract|Compile 晋升合同]] — 前身，定义 Ref compile 规则（不含 lineage 绑定）
+- [[review-decision-contract|ReviewDecision 合同]] — approved/rejected 时关联 ReviewDecision
+- [[reconstruction-contract|AcceptedReconstruction 合同]] — `reconstructionId` 指向 Reconstruction

--- a/docs/current/present-slice-contract.md
+++ b/docs/current/present-slice-contract.md
@@ -1,0 +1,169 @@
+---
+kind: contract
+status: current
+schema_version: 1
+describes: PresentSlice
+implements:
+  - causal-learner/mcp-server/src/core/present-slice.ts
+  - causal-learner/mcp-server/src/core/present-slice-store.ts
+upstream:
+  - reconstruction-contract.md
+  - branch-point-contract.md
+---
+
+# PresentSlice 合同：当前观测面对象化
+
+> v13 §7.1 核心桥接对象。定义 PresentSlice 的职责、Schema、工厂函数、持久化层。
+> 上游依赖：AcceptedReconstruction（重建来源）、BranchPoint（分叉点）
+> 关联实现：`core/present-slice.ts`、`core/present-slice-store.ts`
+
+---
+
+## §1 职责
+
+PresentSlice 是"当下"的显式对象化，是 v13 历史生成本体论的核心桥接对象。
+
+**是什么**：
+- 在某个时刻，从历史 Episode lineage 压缩而来的当前观测面
+- 之后一切 provenance tracing 和 LineageCompileProposal 的起点
+- 关联活跃规律（Regulation）、活跃分叉点（BranchPoint）和重建记录（AcceptedReconstruction）
+
+**不是什么**：
+- 不是整个 Episode——Episode 是原始经历，PresentSlice 是压缩投影
+- 不负责计算 provenance——追溯逻辑由调用方或 ProvenanceLineage 承担
+- 不做 fidelity 回归检查——由 HistoricalCompressionRecord 驱动
+
+---
+
+## §2 Schema
+
+```typescript
+interface PresentSlice {
+  id: string;                      // 格式: "PS_<random_hex_12>"
+  name: string;                    // 人类可读名称
+  episodeIds: string[];            // 来源 Episode ID（历史来源）
+  reconstructionIds: string[];     // 关联 AcceptedReconstruction ID
+  activeRegulationIds: string[];   // 当前活跃规律 ID
+  activeBranchPointIds: string[];  // 当前活跃分叉点 ID
+  compressionSummary: string;      // 压缩过程人类可读说明
+  fidelityScore: number;           // 综合保真度 [0.0, 1.0]
+  stateSnapshotIds: string[];      // 状态快照 ID（v13 §7.1）
+  activeConstraints: string[];     // 当前活跃约束（v13 §7.1）
+  visibleOutcomes: string[];       // 可见结果（v13 §7.1）
+  inferredLatentStates: string[];  // 推断的潜在状态（v13 §7.1）
+  unresolvedUnknowns: string[];    // 未解决的未知项（v13 §7.1）
+  createdAt: ISO8601;
+  createdBy: string;               // "system" | "pipeline" | 具体调用方标识
+}
+```
+
+---
+
+## §3 工厂函数
+
+| 函数 | 签名 | 语义 |
+|------|------|------|
+| `createPresentSlice` | `(input: CreatePresentSliceInput) => PresentSlice` | 直接创建，`fidelityScore` 自动 clamp 到 [0,1] |
+| `buildPresentSliceFromPipeline` | `(snapshot: PipelineSnapshot) => PresentSlice` | 从 pipeline 快照构建，自动计算 fidelity 均值和 compressionSummary |
+
+### §3.1 PipelineSnapshot
+
+`buildPresentSliceFromPipeline` 接受扁平快照，避免直接依赖 `CausalPipeline` 类型（防止循环依赖）：
+
+```typescript
+interface PipelineSnapshot {
+  name: string;
+  episodeIds: string[];
+  reconstructionIds: string[];
+  reconstructionFidelities: number[];  // 用于计算均值 fidelityScore
+  activeRegulationIds: string[];
+  activeBranchPointIds: string[];
+  stateSnapshotIds?: string[];
+  activeConstraints?: string[];
+  visibleOutcomes?: string[];
+  inferredLatentStates?: string[];
+  unresolvedUnknowns?: string[];
+  createdBy?: string;
+}
+```
+
+---
+
+## §4 持久化层（PresentSliceStore）
+
+SQLite（better-sqlite3）持久化层，WAL 模式。
+
+### §4.1 存储 Schema
+
+```sql
+CREATE TABLE present_slices (
+  id             TEXT PRIMARY KEY,
+  name           TEXT NOT NULL,
+  fidelity_score REAL NOT NULL,
+  created_at     TEXT NOT NULL,
+  created_by     TEXT NOT NULL,
+  data           TEXT NOT NULL          -- 完整 PresentSlice JSON
+);
+
+CREATE INDEX idx_ps_fidelity   ON present_slices (fidelity_score);
+CREATE INDEX idx_ps_created_at ON present_slices (created_at);
+```
+
+### §4.2 接口
+
+| 方法 | 签名 | 语义 |
+|------|------|------|
+| `save` | `(slice: PresentSlice) => void` | INSERT OR REPLACE，幂等写入 |
+| `get` | `(id: string) => PresentSlice \| null` | 按主键精确查询 |
+| `listAll` | `(limit?: number) => PresentSlice[]` | 按 created_at 降序，默认 limit=100 |
+| `getLowFidelity` | `(threshold: number, limit?: number) => PresentSlice[]` | fidelity 低于阈值（升序），默认 limit=50 |
+| `getByEpisodeId` | `(episodeId: string) => PresentSlice[]` | JSON 子串匹配 + 精确过滤，返回含该 Episode 的所有 Slice |
+| `getStats` | `() => PresentSliceStoreStats` | 返回 `{ totalCount }` |
+| `close` | `() => void` | 关闭数据库连接 |
+
+---
+
+## §5 不变量
+
+| # | 不变量 | 违反时的后果 |
+|---|--------|-------------|
+| PS1 | `fidelityScore` ∈ [0.0, 1.0]，工厂函数自动 clamp | 聚合计算失真 |
+| PS2 | `id` 格式为 `PS_<hex12>`（PRIMARY KEY 约束） | 主键冲突 |
+| PS3 | `save` 幂等：同 id 重复写入覆盖而非报错 | INSERT OR REPLACE 保证 |
+| PS4 | `getByEpisodeId` 对 JSON 子串匹配后二次精确过滤 | 防止 `"ep1"` 匹配 `"ep10"` 的误判 |
+| PS5 | `buildPresentSliceFromPipeline` 的 fidelityScore = 所有 Reconstruction fidelity 的等权均值 | 无 Reconstruction 时退化为 0 |
+| PS6 | 构造时自动创建目录 + 初始化表（若不存在） | 零配置启动 |
+| PS7 | WAL 模式开启 | 并发读写安全 |
+
+---
+
+## §6 语义定位
+
+```
+Episode (原始经历)
+  └──压缩──→ PresentSlice (当下切片)
+               ├── activeRegulationIds → Regulation (规律层)
+               ├── activeBranchPointIds → BranchPoint (分叉治理)
+               ├── reconstructionIds → AcceptedReconstruction (重建溯源)
+               └── ←── HistoricalCompressionRecord (压缩审计)
+                    └── ←── LineageCompileProposal (lineage 编译提案)
+```
+
+PresentSlice 是 v13 "当前如何由历史生成"的**起点对象**。没有 PresentSlice，LineageCompileProposal 和 HistoricalCompressionRecord 均无法关联。
+
+---
+
+## §7 版本历史
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| 1 | 2026-04-16 | 初版。定义 PresentSlice Schema、工厂函数、PresentSliceStore 持久化层、7 条不变量 |
+
+---
+
+## 参考
+
+- [[branch-point-contract|BranchPoint 合同]] — PresentSlice.activeBranchPointIds 指向 BranchPoint
+- [[reconstruction-contract|AcceptedReconstruction 合同]] — PresentSlice.reconstructionIds 指向 AcceptedReconstruction
+- [[historical-compression-record-contract|HistoricalCompressionRecord 合同]] — 每次压缩操作生成 HCR，targetPresentSliceId 指向本对象
+- [[lineage-compile-proposal-contract|LineageCompileProposal 合同]] — targetPresentSliceId 指向本对象


### PR DESCRIPTION
## Summary

补齐 v11/v13 Kilo 审计缺口——三个已在代码中实现但缺少 `docs/current` 合约的对象。

- **`present-slice-contract.md`**: PresentSlice (PS_<hex12>)，v13 §7.1 核心桥接对象，历史 lineage 压缩到"当下"的显式面；PresentSliceStore 持久化层
- **`lineage-compile-proposal-contract.md`**: LineageCompileProposal (LCP_<hex12>)，v13 §11.1，升级版 CompileProposal，绑定 PresentSlice；6 态状态机 + 9 条不变量
- **`historical-compression-record-contract.md`**: HistoricalCompressionRecord (HCR_<hex12>)，v13 §12.1 G2 根公理落地，"当前态是历史压缩态"审计记录

## Test plan

- [x] `node scripts/contract-audit.mjs` → `errors=0`（本地已验证）
- [x] 三个合约 frontmatter 格式正确（`kind: contract`, `status: current`, `schema_version: 1`, `describes: <TypeName>`）
- [ ] CI `契约真值审计（contract drift gate）` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)