### PR TITLE
docs: 修正 CounterfactualScenario + ExperimentDesign 合约漂移 (#79)

### DIFF
--- a/artifacts/contract-audit-latest.json
+++ b/artifacts/contract-audit-latest.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2026-04-16T13:53:02.239Z",
+  "timestamp": "2026-04-16T13:57:26.147Z",
   "files_scanned": 714,
   "errors": [],
   "warnings": [
@@ -51,6 +51,13 @@
       "code": "describes-too-long",
       "level": "warning",
       "msg": "describes 超过 20 字：54 字"
+    },
+    {
+      "file": "docs/current/counterfactual-scenario-contract.md",
+      "line": 1,
+      "code": "describes-too-long",
+      "level": "warning",
+      "msg": "describes 超过 20 字：22 字"
     },
     {
       "file": "docs/current/historical-compression-record-contract.md",
@@ -292,8 +299,8 @@
     }
   ],
   "summary": {
-    "ok": 695,
-    "warn": 19,
+    "ok": 694,
+    "warn": 20,
     "err": 0
   },
   "kind_distribution": {
@@ -7956,13 +7963,13 @@
     {
       "file": "docs/current/counterfactual-scenario-contract.md",
       "format": "md",
-      "status": "draft",
+      "status": "current",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "反事实场景对象规范",
+      "describes": "CounterfactualScenario",
       "density": 0,
       "errors": 0,
-      "warnings": 0
+      "warnings": 1
     },
     {
       "file": "docs/current/coverage-matrix-contract.md",
@@ -8011,10 +8018,10 @@
     {
       "file": "docs/current/experiment-design-contract.md",
       "format": "md",
-      "status": "draft",
+      "status": "current",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "实验设计对象规范",
+      "describes": "ExperimentDesign",
       "density": 0,
       "errors": 0,
       "warnings": 0

--- a/docs/current/counterfactual-scenario-contract.md
+++ b/docs/current/counterfactual-scenario-contract.md
@@ -1,9 +1,8 @@
 ---
 kind: contract
-status: draft
-phase: 3
+status: current
 schema_version: 1
-describes: "反事实场景对象规范"
+describes: CounterfactualScenario
 upstream:
   - v8_generative_ontology.md
   - mechanism-program-contract.md
@@ -186,34 +185,29 @@ CounterfactualScenario
 
 ## §6 与当前代码的映射
 
-| 目标对象 | 当前最接近对象 | 现状判断 | 升级方向 |
-|---|---|---|---|
-| `CounterfactualScenario` | 无显式对象 | 未实现 | 新增 `core/counterfactual-scenario.ts` / store |
-| `modifiedAssumptions` | 现在仅存在于设计史讨论中 | 未实现 | 新增 |
-| `predictedTrajectory` | `AcceptedReconstruction.reconstructed_timeline` 的未来版 | 未实现 | 可复用其 step 结构风格 |
-| `mechanismProgramRefs` | `MechanismProgram` 已有持久化对象 | 已可对接 | 直接引用 |
+| 目标对象 | 实现位置 | 现状判断 |
+|---|---|---|
+| `CounterfactualScenario` | `core/counterfactual-scenario.ts:36-59` | **已实现**，含不变量校验与 `inferCounterfactual` 推演入口 |
+| `modifiedAssumptions` | `core/counterfactual-scenario.ts:44` | **已实现**，作为 Fact[] 字段 |
+| `predictedTrajectory` | `core/counterfactual-scenario.ts:48` | **已实现**，`inferCounterfactual` 自动生成 |
+| `mechanismProgramRefs` | `core/counterfactual-scenario.ts:46` | **已实现**，引用 MechanismProgram |
+| `CounterfactualScenarioStore` | `core/counterfactual-scenario-store.ts` | **已实现**，SQLite WAL 持久化 |
+
+Pipeline 集成：`core/pipeline.ts:1062-1138` 将 CounterfactualScenario 接入主流程。
 
 ---
 
-## §7 第一轮实现建议
+## §7 实现状态（2026-04-16）
 
-本合同当前仍是 `draft`，第一轮不要求完整反事实模拟引擎。
+**已完成**：
+- `core/counterfactual-scenario.ts`：类型定义 + `inferCounterfactual` 推演引擎
+- `core/counterfactual-scenario-store.ts`：SQLite WAL 持久化（save/get/list/getByEpisode/getStats）
+- `core/pipeline.ts`：pipeline 集成（ExecuteExperimentDesign → Scenario → Design → Execution 闭环）
 
-建议最小实现：
-
-1. 新增 `counterfactual-scenario.ts`
-2. 新增 `counterfactual-scenario-store.ts`
-3. 允许用一个最小占位策略生成 `predictedTrajectory`
-4. 至少支持：
-   - 改一个条件
-   - 生成一条最小预测轨迹
-   - 给出一个 `predictedOutcome`
-
-不要求：
-
-- 多场景搜索
-- 信息增益排序
-- 真正的 experiment planner
+**已知范围限制**（v13 §8 扩展方向）：
+- 多场景搜索（当前单次推演）
+- 信息增益排序（由 `ExperimentDesign.expectedInformationGain` 承担）
+- 真正的 counterfactual 真值验证（当前为结构化占位）
 
 ---
 

--- a/docs/current/experiment-design-contract.md
+++ b/docs/current/experiment-design-contract.md
@@ -1,9 +1,8 @@
 ---
 kind: contract
-status: draft
-phase: 3
+status: current
 schema_version: 1
-describes: "实验设计对象规范"
+describes: ExperimentDesign
 upstream:
   - v8_generative_ontology.md
   - counterfactual-scenario-contract.md
@@ -163,35 +162,29 @@ ExperimentDesign
 
 ## §6 与当前代码的映射
 
-| 目标对象 | 当前最接近对象 | 现状判断 | 升级方向 |
-|---|---|---|---|
-| `ExperimentDesign` | 无显式对象 | 未实现 | 后续新增 `core/experiment-design.ts` / store |
-| `basedOnCounterfactualIds` | `CounterfactualScenario` 已有对象与 store | 已可对接 | 直接引用 |
-| `candidateInterventions` | `ActionClass / Skill` 的自然延伸 | 尚未统一 | 后续与 ActionClass 合同接线 |
-| `expectedInformationGain` | 当前仅存在于 v8 设计史 | 未实现 | 第一轮可先占位 |
+| 目标对象 | 实现位置 | 现状判断 |
+|---|---|---|
+| `ExperimentDesign` | `core/experiment-design.ts:15-42` | **已实现**，含构造器与闭环计算 |
+| `basedOnCounterfactualIds` | `core/experiment-design.ts` | **已实现**，直接引用 CounterfactualScenario |
+| `candidateInterventions` | `core/experiment-design.ts` | **已实现**，ActionClass 自然延伸 |
+| `expectedInformationGain` | `core/experiment-design.ts:143-194` | **已实现**，含 discriminatingPower 计算 |
+| `ExperimentDesignStore` | `core/experiment-design-store.ts:66-106` | **已实现**，SQLite WAL 持久化 |
+
+Pipeline 集成：`core/pipeline.ts:417-419` 将 ExperimentDesign 接入 `executeExperimentDesign` 闭环（Scenario→Design→Execution）。
 
 ---
 
-## §7 第一轮实现建议
+## §7 实现状态（2026-04-16）
 
-本合同当前仍是 `draft`，第一轮不要求完整实验规划引擎。
+**已完成**：
+- `core/experiment-design.ts`：类型定义 + `expectedInformationGain` + `discriminatingPower`
+- `core/experiment-design-store.ts`：SQLite WAL 持久化（save/get/list/getByEpisode/getStats）
+- `core/pipeline.ts`：`executeExperimentDesign` 主流程（CounterfactualScenario→ExperimentDesign→ActionExecution→新 Episode 闭环）
 
-建议最小实现：
-
-1. 新增 `experiment-design.ts`
-2. 新增 `experiment-design-store.ts`
-3. 允许用最小占位策略生成：
-   - `expectedInformationGain`
-   - `discriminatingPower`
-4. 至少支持：
-   - 引用多个 counterfactual
-   - 给出一个推荐 action
-
-不要求：
-
-- 真实信息增益算法
-- 多目标优化
-- 风险最小化求解器
+**已知范围限制**（v13 §8 扩展方向）：
+- 多目标优化（当前单目标 discriminatingPower 排序）
+- 风险最小化求解器（当前占位）
+- 与 ActionClass 合同的完整接线（当前通过 candidateInterventions 字符串列表）
 
 ---
 


### PR DESCRIPTION
## Summary

修正 v13 项目审查中发现的 HIGH 1b 缺口：两个已完整实现的对象（CounterfactualScenario、ExperimentDesign）的合约仍然声明"未实现"，导致决策层可能误判治理范围。

- `counterfactual-scenario-contract.md`: `status: draft` → `current`，§6 全部"未实现"改为"已实现"并标注实现位置，§7 替换为实现状态说明
- `experiment-design-contract.md`: `status: draft` → `current`，§6/§7 同步修正

## Test plan

- [x] `node scripts/contract-audit.mjs` → `errors=0`（本地已验证）
- [ ] CI `契约真值审计（contract drift gate）` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)