### PR TITLE
chore: 清理 contract-audit warnings（42→30）

### DIFF
--- a/docs/current/branch-point-contract.md
+++ b/docs/current/branch-point-contract.md
@@ -1,6 +1,7 @@
 ---
 kind: contract
 status: current
+schema_version: 1
 describes: BranchPointStore
 implements:
   - causal-learner/mcp-server/src/core/branch-point.ts

--- a/docs/current/civilization-memory-contract.md
+++ b/docs/current/civilization-memory-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: draft
 phase: 10
 schema_version: 1
-describes: "FailureBoundaryArchive / CounterexampleCommons 文明记忆层规范"
+describes: "文明记忆层对象规范"
 upstream:
   - participatory-world-contract.md
   - ontology-federation-contract.md

--- a/docs/current/counterfactual-scenario-contract.md
+++ b/docs/current/counterfactual-scenario-contract.md
@@ -11,6 +11,8 @@ downstream:
   - reconstruction-contract.md
 ---
 
+<!-- audit-ignore: describes-too-long -->
+
 # CounterfactualScenario 合同：从重建过去到生成未来的第一对象
 
 ## §1 定位

--- a/docs/current/historical-compression-record-contract.md
+++ b/docs/current/historical-compression-record-contract.md
@@ -10,6 +10,8 @@ upstream:
   - present-slice-contract.md
 ---
 
+<!-- audit-ignore: describes-too-long -->
+
 # HistoricalCompressionRecord 合同：历史压缩审计记录
 
 > v13 §12.1 Civilization Memory Layer 核心审计对象。定义历史压缩操作的记录职责、Schema、不变量、持久化层。

--- a/docs/current/intent-alignment-audit-contract.md
+++ b/docs/current/intent-alignment-audit-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: draft
 phase: 1
 schema_version: 1
-describes: "测试agent与代码编写agent的意图一致性审计协议"
+describes: "意图一致性审计协议"
 ---
 
 # 意图一致性审计合同：测试工程师作为编写者的对话者

--- a/docs/current/lineage-compile-proposal-contract.md
+++ b/docs/current/lineage-compile-proposal-contract.md
@@ -12,6 +12,8 @@ upstream:
   - review-decision-contract.md
 ---
 
+<!-- audit-ignore: describes-too-long -->
+
 # LineageCompileProposal 合同：谱系编译提案
 
 > v13 §11.1 Institutional Compile Layer 核心对象。定义编译提案的职责、状态机、Schema、不变量、持久化层。

--- a/docs/current/ontology-federation-contract.md
+++ b/docs/current/ontology-federation-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: draft
 phase: 7
 schema_version: 1
-describes: "OntologyModel / TranslationFunctor / ConflictSet 本体联邦规范"
+describes: "本体联邦对象规范"
 upstream:
   - v7-world-model-contract.md
   - mechanism-program-contract.md

--- a/docs/current/participatory-world-contract.md
+++ b/docs/current/participatory-world-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: draft
 phase: 9
 schema_version: 1
-describes: "ObserverModel / InstitutionModel 参与式自反世界规范"
+describes: "参与式自反世界规范"
 upstream:
   - ontology-federation-contract.md
   - mechanism-program-contract.md

--- a/docs/current/program-revision-proposal-contract.md
+++ b/docs/current/program-revision-proposal-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: draft
 phase: 4
 schema_version: 1
-describes: "PredictionError 驱动的模型修正提名对象"
+describes: "模型修正提名对象"
 upstream:
   - prediction-error-contract.md
   - mechanism-program-contract.md

--- a/docs/current/reconstruction-store-contract.md
+++ b/docs/current/reconstruction-store-contract.md
@@ -1,6 +1,7 @@
 ---
 kind: contract
 status: current
+schema_version: 1
 describes: ReconstructionStore
 implements:
   - causal-learner/mcp-server/src/core/reconstruction-store.ts

--- a/docs/current/review-decision-contract.md
+++ b/docs/current/review-decision-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: current
 phase: 4
 schema_version: 1
-describes: "ProgramRevisionProposal 审查决策对象规范"
+describes: "审查决策对象规范"
 upstream:
   - program-revision-proposal-contract.md
   - ontology-delta-contract.md

--- a/docs/current/testing-strategy-contract.md
+++ b/docs/current/testing-strategy-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: draft
 phase: 1
 schema_version: 1
-describes: "OpenAGI级测试验证体系与运行时信息收集规范"
+describes: "测试验证策略规范"
 ---
 
 # 测试验证策略合同：为80亿人类服务的OpenAGI项目的质量保证体系

--- a/docs/current/v11-world-model-contract.md
+++ b/docs/current/v11-world-model-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: draft
 phase: 11
 schema_version: 1
-describes: "ProofLineage / ConstitutionalLayer 反射性文明引擎规范"
+describes: "反射性文明引擎规范"
 upstream:
   - civilization-memory-contract.md
   - participatory-world-contract.md

--- a/docs/current/validity-envelope-contract.md
+++ b/docs/current/validity-envelope-contract.md
@@ -3,7 +3,7 @@ kind: contract
 status: draft
 phase: 4
 schema_version: 1
-describes: "MechanismProgram 有效域对象规范"
+describes: "有效域对象规范"
 upstream:
   - mechanism-program-contract.md
   - prediction-error-contract.md


### PR DESCRIPTION
## Summary
- 补 schema_version: branch-point, reconstruction-store (2 个)
- 缩短 describes 到 ≤20 字: 9 个合约（civilization-memory、intent-alignment-audit 等）
- 3 个 TypeScript 类型名合约加 \`<!-- audit-ignore: describes-too-long -->\`: counterfactual-scenario (22), lineage-compile-proposal (22), historical-compression-record (27)

## 验证
- contract-audit: errors=0, warnings 42→30
- tests: 320 pass / 0 fail

## 剩余 warnings 性质
- 22 duplicate-truth: 不同对象的 describes 用相同 "X 对象规范" 结构 → Jaccard 相似（低优，非 drift）
- 7 symbol-drift: 跨合约引用（如 prediction-error 提到 executeExperimentDesign）→ 本质是信息性提示
- 1 type2-too-much-substance: testing-roadmap-v7-to-v11 index density 低

这些都是低优先级，后续批次再处理。