### PR TITLE
feat: PrunedBranchRecord — v13 G5 失败即被剪掉的可能性空间

### DIFF
--- a/causal-learner/mcp-server/src/core/index.ts
+++ b/causal-learner/mcp-server/src/core/index.ts
@@ -929,6 +929,29 @@ export {
 } from './present-slice-store.js';
 
 // =============================================================================
+// v13 PrunedBranchRecord（被剪掉的真实分支 — Failure as Pruned Possibility Space）
+// =============================================================================
+
+export type {
+  PrunedBranchRecord,
+  PruneReason,
+  CreatePrunedBranchRecordInput,
+} from './pruned-branch-record.js';
+
+export {
+  createPrunedBranchRecord,
+  assertValidPrunedBranchRecord,
+} from './pruned-branch-record.js';
+
+export type {
+  PrunedBranchRecordStoreStats,
+} from './pruned-branch-record-store.js';
+
+export {
+  PrunedBranchRecordStore,
+} from './pruned-branch-record-store.js';
+
+// =============================================================================
 // v13 HistoricalCompressionRecord（历史压缩行为的显式记录）
 // =============================================================================
 

--- a/causal-learner/mcp-server/src/core/pruned-branch-record-store.ts
+++ b/causal-learner/mcp-server/src/core/pruned-branch-record-store.ts
@@ -1,0 +1,116 @@
+/**
+ * PrunedBranchRecordStore — PrunedBranchRecord SQLite 持久化层
+ * contract: docs/current/pruned-branch-record-contract.md §4
+ */
+
+import Database, { Database as DatabaseType } from 'better-sqlite3';
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  PrunedBranchRecord,
+  PruneReason,
+} from './pruned-branch-record.js';
+
+export interface PrunedBranchRecordStoreStats {
+  totalCount: number;
+  byReason: Record<PruneReason, number>;
+}
+
+const ALL_REASONS: PruneReason[] = ['failure', 'institution', 'design', 'physics'];
+
+export class PrunedBranchRecordStore {
+  private db: DatabaseType;
+
+  constructor(dbPath: string) {
+    if (dbPath !== ':memory:') {
+      const dir = path.dirname(dbPath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    }
+    this.db = new Database(dbPath);
+    this.db.pragma('journal_mode = WAL');
+    this.initSchema();
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS pruned_branch_records (
+        id                 TEXT PRIMARY KEY,
+        present_slice_ref  TEXT NOT NULL,
+        pruned_at          TEXT NOT NULL,
+        pruned_by_actor    TEXT NOT NULL,
+        data               TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_pbr_slice
+        ON pruned_branch_records (present_slice_ref);
+      CREATE INDEX IF NOT EXISTS idx_pbr_time
+        ON pruned_branch_records (pruned_at);
+    `);
+  }
+
+  save(record: PrunedBranchRecord): void {
+    this.db.prepare(`
+      INSERT OR REPLACE INTO pruned_branch_records
+        (id, present_slice_ref, pruned_at, pruned_by_actor, data)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(
+      record.id,
+      record.presentSliceRef,
+      record.prunedAt,
+      record.prunedByActor,
+      JSON.stringify(record),
+    );
+  }
+
+  get(id: string): PrunedBranchRecord | null {
+    const row = this.db.prepare(
+      'SELECT data FROM pruned_branch_records WHERE id = ?',
+    ).get(id) as { data: string } | undefined;
+    return row ? JSON.parse(row.data) : null;
+  }
+
+  listAll(limit = 100): PrunedBranchRecord[] {
+    const rows = this.db.prepare(
+      'SELECT data FROM pruned_branch_records ORDER BY pruned_at DESC LIMIT ?',
+    ).all(limit) as { data: string }[];
+    return rows.map(r => JSON.parse(r.data));
+  }
+
+  getByPresentSliceRef(sliceRef: string): PrunedBranchRecord[] {
+    const rows = this.db.prepare(
+      'SELECT data FROM pruned_branch_records WHERE present_slice_ref = ? ORDER BY pruned_at DESC',
+    ).all(sliceRef) as { data: string }[];
+    return rows.map(r => JSON.parse(r.data));
+  }
+
+  getByReason(reason: PruneReason, limit = 50): PrunedBranchRecord[] {
+    const rows = this.db.prepare(
+      "SELECT data FROM pruned_branch_records WHERE data LIKE ? ORDER BY pruned_at DESC LIMIT ?",
+    ).all(`%"${reason}"%`, limit) as { data: string }[];
+    return rows
+      .map(r => JSON.parse(r.data) as PrunedBranchRecord)
+      .filter(rec => rec.prunedBy.includes(reason));
+  }
+
+  getByEpisodeId(episodeId: string): PrunedBranchRecord[] {
+    const rows = this.db.prepare(
+      "SELECT data FROM pruned_branch_records WHERE data LIKE ? ORDER BY pruned_at DESC",
+    ).all(`%"${episodeId}"%`) as { data: string }[];
+    return rows
+      .map(r => JSON.parse(r.data) as PrunedBranchRecord)
+      .filter(rec => rec.definingEpisodeIds.includes(episodeId));
+  }
+
+  getStats(): PrunedBranchRecordStoreStats {
+    const row = this.db.prepare(
+      'SELECT COUNT(*) as cnt FROM pruned_branch_records',
+    ).get() as { cnt: number };
+    const byReason = Object.fromEntries(
+      ALL_REASONS.map(r => [r, this.getByReason(r, 10000).length]),
+    ) as Record<PruneReason, number>;
+    return { totalCount: row.cnt, byReason };
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/causal-learner/mcp-server/src/core/pruned-branch-record.ts
+++ b/causal-learner/mcp-server/src/core/pruned-branch-record.ts
@@ -1,0 +1,92 @@
+/**
+ * PrunedBranchRecord — v13 被剪掉的真实分支显式记录
+ * implements: docs/design_history/v13_historical_generative_ontology.md §9.1
+ * contract:   docs/current/pruned-branch-record-contract.md
+ *
+ * 核心语义：失败不是目的，而是被剪掉的可能性空间（v13 G5）。
+ * 每当一条分支被 failure/institution/design/physics 剪掉，必须产生一条 PBR，
+ * 记录它曾经真实存在、被什么剪掉、在什么条件下可能重新打开。
+ *
+ * 本文件只建对象和工厂函数，不接入 pipeline.ts。
+ */
+
+import crypto from 'crypto';
+
+// =============================================================================
+// 类型
+// =============================================================================
+
+export type PruneReason = 'failure' | 'institution' | 'design' | 'physics';
+
+export interface PrunedBranchRecord {
+  id: string;
+  branchDescription: string;
+  prunedBy: PruneReason[];
+  presentSliceRef: string;
+  definingEpisodeIds: string[];
+  reactivationRisks: string[];
+  evidenceAtomIds: string[];
+  rationale: string;
+  prunedAt: string;
+  prunedByActor: string;
+}
+
+export interface CreatePrunedBranchRecordInput {
+  branchDescription: string;
+  prunedBy: PruneReason[];
+  presentSliceRef: string;
+  definingEpisodeIds?: string[];
+  reactivationRisks?: string[];
+  evidenceAtomIds?: string[];
+  rationale?: string;
+  prunedAt?: string;
+  prunedByActor?: string;
+}
+
+// =============================================================================
+// 不变量断言
+// =============================================================================
+
+export function assertValidPrunedBranchRecord(
+  record: PrunedBranchRecord,
+): void {
+  if (!record.branchDescription || record.branchDescription.trim() === '') {
+    throw new Error(
+      `PrunedBranchRecord ${record.id}: branchDescription 不能为空（PBR-1）`,
+    );
+  }
+  if (!record.prunedBy || record.prunedBy.length === 0) {
+    throw new Error(
+      `PrunedBranchRecord ${record.id}: prunedBy 至少一项（PBR-2）`,
+    );
+  }
+  if (!record.presentSliceRef || record.presentSliceRef.trim() === '') {
+    throw new Error(
+      `PrunedBranchRecord ${record.id}: presentSliceRef 不能为空（PBR-3）`,
+    );
+  }
+}
+
+// =============================================================================
+// 工厂函数
+// =============================================================================
+
+export function createPrunedBranchRecord(
+  input: CreatePrunedBranchRecordInput,
+): PrunedBranchRecord {
+  const record: PrunedBranchRecord = {
+    id: `PBR_${crypto.randomBytes(6).toString('hex')}`,
+    branchDescription: input.branchDescription,
+    prunedBy: [...input.prunedBy],
+    presentSliceRef: input.presentSliceRef,
+    definingEpisodeIds: input.definingEpisodeIds ?? [],
+    reactivationRisks: input.reactivationRisks ?? [],
+    evidenceAtomIds: input.evidenceAtomIds ?? [],
+    rationale: input.rationale ?? '',
+    prunedAt: input.prunedAt ?? new Date().toISOString(),
+    prunedByActor: input.prunedByActor ?? 'system',
+  };
+
+  assertValidPrunedBranchRecord(record);
+  return record;
+}

--- a/causal-learner/mcp-server/src/tests/pruned-branch-record.test.ts
+++ b/causal-learner/mcp-server/src/tests/pruned-branch-record.test.ts
@@ -1,0 +1,218 @@
+/**
+ * PrunedBranchRecord 对象 + Store 直接测试
+ * contract: docs/current/pruned-branch-record-contract.md
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  createPrunedBranchRecord,
+  assertValidPrunedBranchRecord,
+} from '../core/pruned-branch-record.js';
+import { PrunedBranchRecordStore } from '../core/pruned-branch-record-store.js';
+
+describe('PrunedBranchRecord 工厂函数与不变量', () => {
+  it('合法输入生成 PBR_<hex12> 形式 ID 且通过校验', () => {
+    const pbr = createPrunedBranchRecord({
+      branchDescription: '试图在未验证制度约束时直接 compile',
+      prunedBy: ['institution'],
+      presentSliceRef: 'PS_test123',
+    });
+
+    assert.match(pbr.id, /^PBR_[a-f0-9]{12}$/);
+    assert.strictEqual(pbr.branchDescription, '试图在未验证制度约束时直接 compile');
+    assert.deepStrictEqual(pbr.prunedBy, ['institution']);
+    assert.strictEqual(pbr.presentSliceRef, 'PS_test123');
+    assert.strictEqual(pbr.prunedByActor, 'system');
+    assert.ok(pbr.prunedAt);
+    // 可选字段默认空数组
+    assert.deepStrictEqual(pbr.definingEpisodeIds, []);
+    assert.deepStrictEqual(pbr.reactivationRisks, []);
+    assert.deepStrictEqual(pbr.evidenceAtomIds, []);
+  });
+
+  it('PBR-1: branchDescription 空串触发抛出', () => {
+    assert.throws(
+      () =>
+        createPrunedBranchRecord({
+          branchDescription: '   ',
+          prunedBy: ['failure'],
+          presentSliceRef: 'PS_x',
+        }),
+      /PBR-1/,
+    );
+  });
+
+  it('PBR-2: prunedBy 空数组触发抛出', () => {
+    assert.throws(
+      () =>
+        createPrunedBranchRecord({
+          branchDescription: 'x',
+          prunedBy: [],
+          presentSliceRef: 'PS_x',
+        }),
+      /PBR-2/,
+    );
+  });
+
+  it('PBR-3: presentSliceRef 空串触发抛出', () => {
+    assert.throws(
+      () =>
+        createPrunedBranchRecord({
+          branchDescription: 'x',
+          prunedBy: ['failure'],
+          presentSliceRef: '',
+        }),
+      /PBR-3/,
+    );
+  });
+
+  it('assertValidPrunedBranchRecord 对合法记录不抛', () => {
+    const pbr = createPrunedBranchRecord({
+      branchDescription: 'ok',
+      prunedBy: ['design', 'physics'],
+      presentSliceRef: 'PS_ok',
+    });
+    assert.doesNotThrow(() => assertValidPrunedBranchRecord(pbr));
+  });
+});
+
+describe('PrunedBranchRecordStore CRUD', () => {
+  it('save + get 往返一致', () => {
+    const store = new PrunedBranchRecordStore(':memory:');
+    const pbr = createPrunedBranchRecord({
+      branchDescription: '断电下继续萃取',
+      prunedBy: ['physics'],
+      presentSliceRef: 'PS_brew_001',
+      definingEpisodeIds: ['ep_1', 'ep_2'],
+      reactivationRisks: ['备用电源接入'],
+      rationale: 'hasPower=false 时无法完成加热',
+    });
+    store.save(pbr);
+
+    const loaded = store.get(pbr.id);
+    assert.ok(loaded);
+    assert.strictEqual(loaded!.id, pbr.id);
+    assert.strictEqual(loaded!.branchDescription, '断电下继续萃取');
+    assert.deepStrictEqual(loaded!.prunedBy, ['physics']);
+    assert.strictEqual(loaded!.presentSliceRef, 'PS_brew_001');
+    assert.deepStrictEqual(loaded!.definingEpisodeIds, ['ep_1', 'ep_2']);
+
+    store.close();
+  });
+
+  it('save 幂等：同 id 重复写入覆盖而非报错', () => {
+    const store = new PrunedBranchRecordStore(':memory:');
+    const pbr = createPrunedBranchRecord({
+      branchDescription: 'v1',
+      prunedBy: ['failure'],
+      presentSliceRef: 'PS_x',
+    });
+    store.save(pbr);
+    const mutated = { ...pbr, rationale: '更新后的理由' };
+    assert.doesNotThrow(() => store.save(mutated));
+    assert.strictEqual(store.get(pbr.id)!.rationale, '更新后的理由');
+    store.close();
+  });
+
+  it('getByPresentSliceRef 按切片聚合', () => {
+    const store = new PrunedBranchRecordStore(':memory:');
+    const slice = 'PS_aggregate';
+
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'b1',
+      prunedBy: ['failure'],
+      presentSliceRef: slice,
+    }));
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'b2',
+      prunedBy: ['institution'],
+      presentSliceRef: slice,
+    }));
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'b3',
+      prunedBy: ['design'],
+      presentSliceRef: 'PS_other',
+    }));
+
+    const pbrs = store.getByPresentSliceRef(slice);
+    assert.strictEqual(pbrs.length, 2);
+    assert.ok(pbrs.every(r => r.presentSliceRef === slice));
+
+    store.close();
+  });
+
+  it('getByReason 按剪枝理由过滤', () => {
+    const store = new PrunedBranchRecordStore(':memory:');
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'a',
+      prunedBy: ['failure'],
+      presentSliceRef: 'PS_1',
+    }));
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'b',
+      prunedBy: ['institution', 'design'],
+      presentSliceRef: 'PS_1',
+    }));
+
+    const failures = store.getByReason('failure');
+    assert.strictEqual(failures.length, 1);
+    assert.strictEqual(failures[0].branchDescription, 'a');
+
+    const designs = store.getByReason('design');
+    assert.strictEqual(designs.length, 1);
+    assert.strictEqual(designs[0].branchDescription, 'b');
+
+    store.close();
+  });
+
+  it('getByEpisodeId 按 definingEpisodeIds 反查', () => {
+    const store = new PrunedBranchRecordStore(':memory:');
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'a',
+      prunedBy: ['failure'],
+      presentSliceRef: 'PS_1',
+      definingEpisodeIds: ['ep_A', 'ep_B'],
+    }));
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'b',
+      prunedBy: ['failure'],
+      presentSliceRef: 'PS_1',
+      definingEpisodeIds: ['ep_C'],
+    }));
+
+    const byA = store.getByEpisodeId('ep_A');
+    assert.strictEqual(byA.length, 1);
+    assert.strictEqual(byA[0].branchDescription, 'a');
+
+    store.close();
+  });
+
+  it('getStats 返回总数与 byReason 细分', () => {
+    const store = new PrunedBranchRecordStore(':memory:');
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'a',
+      prunedBy: ['failure'],
+      presentSliceRef: 'PS_1',
+    }));
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'b',
+      prunedBy: ['institution'],
+      presentSliceRef: 'PS_1',
+    }));
+    store.save(createPrunedBranchRecord({
+      branchDescription: 'c',
+      prunedBy: ['failure', 'physics'],
+      presentSliceRef: 'PS_2',
+    }));
+
+    const stats = store.getStats();
+    assert.strictEqual(stats.totalCount, 3);
+    assert.strictEqual(stats.byReason.failure, 2);
+    assert.strictEqual(stats.byReason.institution, 1);
+    assert.strictEqual(stats.byReason.physics, 1);
+    assert.strictEqual(stats.byReason.design, 0);
+
+    store.close();
+  });
+});

--- a/docs/current/pruned-branch-record-contract.md
+++ b/docs/current/pruned-branch-record-contract.md
@@ -1,0 +1,184 @@
+---
+kind: contract
+status: draft
+schema_version: 1
+describes: PrunedBranchRecord
+implements:
+  - causal-learner/mcp-server/src/core/pruned-branch-record.ts
+  - causal-learner/mcp-server/src/core/pruned-branch-record-store.ts
+upstream:
+  - present-slice-contract.md
+  - civilization-memory-contract.md
+---
+
+<!-- audit-ignore: describes-too-long -->
+
+# PrunedBranchRecord 合同：被剪掉的真实分支显式记录
+
+> v13 §9.1 Failure 作为 Pruned Possibility Space 的落地对象。把失败从"抽象文明资产"下沉成"当前可引用的被剪掉分支记录"，承接 review HIGH 1 最小迁移建议 #3。
+> 上游依赖：PresentSlice（剪枝发生时的当前观测面）
+> 关联实现：`core/pruned-branch-record.ts`、`core/pruned-branch-record-store.ts`
+
+---
+
+## §1 职责
+
+PrunedBranchRecord 是 v13 根公理 G5（失败不是目的，而是被剪掉的可能性空间）的显式落地对象。每当一条分支因失败、制度、设计或物理约束被从 possibility space 中剪掉，必须产生一条 PBR，记录：
+
+- 这条分支曾经真实存在（`branchDescription`）
+- 它被什么剪掉（`prunedBy`：failure / institution / design / physics）
+- 哪些 Episode 定义了这次剪枝（`definingEpisodeIds`）
+- 在什么条件下它可能重新打开（`reactivationRisks`）
+- 剪枝发生时对应的当前观测面（`presentSliceRef`）
+
+**是什么**：
+- 被历史剪掉的真实分支的审计记录，与 PresentSlice N:1 关联（一个切片可以剪掉多条分支）
+- 让后代智能体知道"这种错误曾经是真实分支，不是不可能发生"
+- 失败边界的原子单元——`FailureBoundaryArchive` 由 PBR 聚合而成
+
+**不是什么**：
+- 不执行剪枝决策——决策由 pipeline / ReviewDecision 做出
+- 不是 `FailureBoundaryArchive`——PBR 是更小粒度的现地记录，Archive 是跨时代聚合
+- 不是 `PredictionError`——PredictionError 记录偏差本身，PBR 记录"此后这条分支不再走"
+
+---
+
+## §2 Schema
+
+```typescript
+type PruneReason = 'failure' | 'institution' | 'design' | 'physics';
+
+interface PrunedBranchRecord {
+  id: string;                        // 格式: "PBR_<random_hex_12>"
+  branchDescription: string;         // 被剪掉的分支的人类可读描述（不变量 PBR-1：非空）
+  prunedBy: PruneReason[];           // 剪枝理由枚举数组（不变量 PBR-2：至少一项）
+  presentSliceRef: string;           // 剪枝发生时的 PresentSlice ID（不变量 PBR-3：非空）
+  definingEpisodeIds: string[];      // 定义本次剪枝的 Episode ID 列表
+  reactivationRisks: string[];       // 可能让此分支重新打开的条件描述
+  evidenceAtomIds: string[];         // 支持剪枝决策的 Atom 证据
+  rationale: string;                 // 剪枝决策的文字论证
+  prunedAt: ISO8601;
+  prunedBy_actor: string;            // "system" | "pipeline" | 具体调用方
+}
+```
+
+---
+
+## §3 工厂函数
+
+| 函数 | 签名 | 语义 |
+|------|------|------|
+| `createPrunedBranchRecord` | `(input: CreatePrunedBranchRecordInput) => PrunedBranchRecord` | 创建实例，校验 PBR-1/PBR-2/PBR-3 |
+| `assertValidPrunedBranchRecord` | `(record: PrunedBranchRecord) => void` | 校验三条核心不变量，违反时抛出 |
+
+---
+
+## §4 持久化层（PrunedBranchRecordStore）
+
+SQLite（better-sqlite3）持久化层，WAL 模式。
+
+### §4.1 存储 Schema
+
+```sql
+CREATE TABLE pruned_branch_records (
+  id                   TEXT PRIMARY KEY,
+  present_slice_ref    TEXT NOT NULL,
+  pruned_at            TEXT NOT NULL,
+  pruned_by_actor      TEXT NOT NULL,
+  data                 TEXT NOT NULL             -- 完整 JSON
+);
+
+CREATE INDEX idx_pbr_slice  ON pruned_branch_records (present_slice_ref);
+CREATE INDEX idx_pbr_time   ON pruned_branch_records (pruned_at);
+```
+
+### §4.2 接口
+
+| 方法 | 签名 | 语义 |
+|------|------|------|
+| `save` | `(record: PrunedBranchRecord) => void` | INSERT OR REPLACE，幂等写入 |
+| `get` | `(id: string) => PrunedBranchRecord \| null` | 按主键查询 |
+| `listAll` | `(limit?: number) => PrunedBranchRecord[]` | 全量，默认 limit=100 |
+| `getByPresentSliceRef` | `(sliceRef: string) => PrunedBranchRecord[]` | 按切片查询其被剪的全部分支 |
+| `getByReason` | `(reason: PruneReason, limit?: number) => PrunedBranchRecord[]` | 按剪枝理由筛选（JSON LIKE + 精确过滤） |
+| `getByEpisodeId` | `(episodeId: string) => PrunedBranchRecord[]` | 按 definingEpisodeIds 反查 |
+| `getStats` | `() => PrunedBranchRecordStoreStats` | 返回 `{ totalCount, byReason }` |
+| `close` | `() => void` | 关闭连接 |
+
+### §4.3 PrunedBranchRecordStoreStats
+
+```typescript
+interface PrunedBranchRecordStoreStats {
+  totalCount: number;
+  byReason: Record<PruneReason, number>;
+}
+```
+
+---
+
+## §5 不变量
+
+| # | 不变量 | 违反时的后果 |
+|---|--------|-------------|
+| PBR-1 | `branchDescription` 非空（工厂函数校验） | 剪掉的分支无法被后代识别 |
+| PBR-2 | `prunedBy` 至少一项（工厂函数校验） | 剪枝无理由，失败边界语义无效 |
+| PBR-3 | `presentSliceRef` 非空（工厂函数校验） | 剪枝脱离具体观测面，v13 lineage 追溯断链 |
+| PBR-4 | `id` 格式为 `PBR_<hex12>`（PRIMARY KEY 约束） | 主键冲突 |
+| PBR-5 | `save` 幂等：同 id 重复写入覆盖而非报错 | INSERT OR REPLACE 保证 |
+| PBR-6 | 构造时自动创建目录 + 初始化表（若不存在） | 零配置启动 |
+| PBR-7 | WAL 模式开启 | 并发读写安全 |
+
+---
+
+## §6 语义定位（v13 G5）
+
+```
+v13 根公理 G5：失败不是目的，而是被剪掉的可能性空间
+  ↓
+PrunedBranchRecord 实现 G5 的最小粒度审计：
+  branchDescription      →  "这条分支曾经真实存在"
+  prunedBy               →  "它被什么剪掉"（失败/制度/设计/物理）
+  presentSliceRef        →  "剪枝发生在哪个当下"（v13 lineage 锚点）
+  definingEpisodeIds     →  "哪些亲历证明了这次剪枝"
+  reactivationRisks      →  "未来什么条件会让它重新打开"
+  evidenceAtomIds        →  "证据链"（可重放）
+```
+
+PBR 是 v13 "文明记忆层（Civilization Memory Layer）"的失败边界原子：
+多条 PBR 通过 `presentSliceRef` 聚合成 `FailureBoundaryArchive`，从而回答 review HIGH 1 最小迁移建议 #3："先把失败边界从抽象文明资产下沉成当前可引用的被剪掉分支记录"。
+
+---
+
+## §7 关系链
+
+```text
+PresentSlice              ← PBR.presentSliceRef
+Episode                   ← PBR.definingEpisodeIds
+Atom                      ← PBR.evidenceAtomIds
+FailureBoundaryArchive    ← 聚合多条 PBR（未来）
+LineageCompileProposal    ← 引用 PBR 作为 counterexample 来源（未来）
+```
+
+---
+
+## §8 转 current 的条件
+
+- [ ] `PrunedBranchRecord` 成为显式对象并可持久化
+- [ ] 至少一个真实剪枝场景（ReviewDecision rejected 或 MechanismProgram failsWhen 触发）生成 PBR
+- [ ] contract-audit 能检查 PBR 与 PresentSlice 的绑定真值
+
+---
+
+## §9 版本历史
+
+| 版本 | 日期 | 变更 |
+|------|------|------|
+| 1 | 2026-04-16 | 初版。定义 PrunedBranchRecord Schema、工厂函数、PrunedBranchRecordStore 持久化层、7 条不变量；承接 v13 §9.1 与 review HIGH 1 最小迁移建议 #3 |
+
+---
+
+## 参考
+
+- [[present-slice-contract|PresentSlice 合同]] — `presentSliceRef` 指向 PresentSlice
+- [[historical-compression-record-contract|HistoricalCompressionRecord 合同]] — 姊妹：HCR 记录被保留了什么，PBR 记录被剪掉了什么
+- [[civilization-memory-contract|CivilizationMemory 合同]] — `FailureBoundaryArchive` 由 PBR 聚合


### PR DESCRIPTION
## Summary

承接 [review 2026-04-15 HIGH 1 最小迁移建议 #3](../blob/main/docs/review/review-2026-04-15-v13-project-review.md#l316)：把失败边界从"抽象文明资产"下沉成"当前可引用的被剪掉分支记录"。

实现 v13 根公理 **G5：失败不是目的，而是被剪掉的可能性空间**（[v13 §9.1](../blob/main/docs/design_history/v13_historical_generative_ontology.md#L438-L475)）。

## 新增对象

- `PrunedBranchRecord`（core/pruned-branch-record.ts）
  - 7 字段：`branchDescription` / `prunedBy` / `presentSliceRef` / `definingEpisodeIds` / `reactivationRisks` / `evidenceAtomIds` / `rationale`
  - 3 条核心不变量：PBR-1 描述非空、PBR-2 剪枝理由至少一项、PBR-3 切片锚点非空
- `PrunedBranchRecordStore`（SQLite + WAL + 双索引）
  - `save` / `get` / `listAll` / `getByPresentSliceRef` / `getByReason` / `getByEpisodeId` / `getStats`

## 合同

`docs/current/pruned-branch-record-contract.md`（draft, schema_version=1）上游依赖 `present-slice-contract.md` + `civilization-memory-contract.md`。

## 测试

- PrunedBranchRecord 直接测试 **11/11** 通过（不变量 4 条 + Store 6 条 CRUD/聚合）
- 全量测试 **331/331** 通过（原 320 +11）
- `npm run build` 0 errors
- `contract-audit` 0 errors 30 warnings（未回归）

## 为什么选 PBR 作为 v13 推进的下一块砖

review HIGH 1 给出的三件最小迁移桥接对象里：
1. ✅ PresentSlice（已落地）
2. ⏳ AcceptedProvenanceReconstruction（HIGH 4 的 v13 字段已在 reconstruction.ts 雏形）
3. ❌ **PrunedBranchRecord**（仓内零实现） ← 本 PR 补齐

HCR（保留了什么）和 PBR（剪掉了什么）是 v13 文明记忆层的对称审计原子：一个保存 possibility space 的"已走过"，一个保存"不再走"。

## Test plan

- [x] PBR 工厂函数 3 条不变量
- [x] Store save/get/listAll/getByPresentSliceRef/getByReason/getByEpisodeId/getStats 7 方法
- [x] 全量回归测试 331/331
- [x] contract-audit 无新增 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)