### PR TITLE
feat: PrunedBranchRecord 接入 pipeline + metamodel 升级到 v13 层

### DIFF
--- a/artifacts/contract-audit-latest.json
+++ b/artifacts/contract-audit-latest.json
@@ -1,6 +1,6 @@
 {
-  "timestamp": "2026-04-16T13:57:26.147Z",
-  "files_scanned": 714,
+  "timestamp": "2026-04-16T16:06:34.251Z",
+  "files_scanned": 715,
   "errors": [],
   "warnings": [
     {
@@ -39,53 +39,18 @@
       "msg": "describes 与 docs/current/transition-contract.md 相似（Jaccard=0.60）"
     },
     {
-      "file": "docs/current/branch-point-contract.md",
+      "file": "docs/current/ontology-delta-contract.md",
       "line": 1,
-      "code": "missing-schema-version",
+      "code": "duplicate-truth",
       "level": "warning",
-      "msg": "kind: contract 建议有 `schema_version:` 字段（int）"
-    },
-    {
-      "file": "docs/current/civilization-memory-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：54 字"
-    },
-    {
-      "file": "docs/current/counterfactual-scenario-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：22 字"
-    },
-    {
-      "file": "docs/current/historical-compression-record-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：27 字"
-    },
-    {
-      "file": "docs/current/intent-alignment-audit-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：27 字"
-    },
-    {
-      "file": "docs/current/lineage-compile-proposal-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：22 字"
+      "msg": "describes 与 docs/current/ontology-federation-contract.md 相似（Jaccard=0.56）"
     },
     {
       "file": "docs/current/ontology-federation-contract.md",
       "line": 1,
-      "code": "describes-too-long",
+      "code": "duplicate-truth",
       "level": "warning",
-      "msg": "describes 超过 20 字：55 字"
+      "msg": "describes 与 docs/current/ontology-delta-contract.md 相似（Jaccard=0.56）"
     },
     {
       "file": "docs/current/outcome-record-contract.md",
@@ -121,13 +86,6 @@
       "code": "duplicate-truth",
       "level": "warning",
       "msg": "describes 与 docs/current/transition-contract.md 相似（Jaccard=0.60）"
-    },
-    {
-      "file": "docs/current/participatory-world-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：42 字"
     },
     {
       "file": "docs/current/prediction-error-contract.md",
@@ -170,27 +128,6 @@
       "code": "duplicate-truth",
       "level": "warning",
       "msg": "describes 与 docs/current/transition-contract.md 相似（Jaccard=0.60）"
-    },
-    {
-      "file": "docs/current/program-revision-proposal-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：27 字"
-    },
-    {
-      "file": "docs/current/reconstruction-store-contract.md",
-      "line": 1,
-      "code": "missing-schema-version",
-      "level": "warning",
-      "msg": "kind: contract 建议有 `schema_version:` 字段（int）"
-    },
-    {
-      "file": "docs/current/review-decision-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：32 字"
     },
     {
       "file": "docs/current/review-decision-contract.md",
@@ -242,13 +179,6 @@
       "msg": "index 引用密度过低 density=0.0%（<70% 可能夹带 substance）"
     },
     {
-      "file": "docs/current/testing-strategy-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：24 字"
-    },
-    {
       "file": "docs/current/transition-contract.md",
       "line": 118,
       "code": "symbol-drift",
@@ -282,29 +212,15 @@
       "code": "duplicate-truth",
       "level": "warning",
       "msg": "describes 与 docs/current/state-snapshot-contract.md 相似（Jaccard=0.60）"
-    },
-    {
-      "file": "docs/current/v11-world-model-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：44 字"
-    },
-    {
-      "file": "docs/current/validity-envelope-contract.md",
-      "line": 1,
-      "code": "describes-too-long",
-      "level": "warning",
-      "msg": "describes 超过 20 字：24 字"
     }
   ],
   "summary": {
-    "ok": 694,
-    "warn": 20,
+    "ok": 706,
+    "warn": 9,
     "err": 0
   },
   "kind_distribution": {
-    "contract": 57,
+    "contract": 58,
     "instance": 641,
     "record": 2,
     "code": 12,
@@ -328,10 +244,7 @@
     "missing_implements": [],
     "bad_implements_target": [],
     "implements_wrong_kind": [],
-    "missing_schema_version": [
-      "docs/current/branch-point-contract.md",
-      "docs/current/reconstruction-store-contract.md"
-    ],
+    "missing_schema_version": [],
     "bad_mechanism_instance_ref": [],
     "bad_ontology_delta_ref": [],
     "trace_reconstruction_mismatch": [],
@@ -474,7 +387,7 @@
     {
       "file": "docs/current/historical-compression-record-contract.md",
       "kind": "contract",
-      "density": 0.0432
+      "density": 0.0426
     },
     {
       "file": "docs/current/hypothesis-contract.md",
@@ -504,7 +417,7 @@
     {
       "file": "docs/current/lineage-compile-proposal-contract.md",
       "kind": "contract",
-      "density": 0.043
+      "density": 0.0426
     },
     {
       "file": "docs/current/mechanism-class-contract.md",
@@ -595,6 +508,11 @@
       "file": "docs/current/program-revision-proposal-contract.md",
       "kind": "contract",
       "density": 0
+    },
+    {
+      "file": "docs/current/pruned-branch-record-contract.md",
+      "kind": "contract",
+      "density": 0.0492
     },
     {
       "file": "docs/current/reconstruction-contract.md",
@@ -7914,7 +7832,7 @@
       "describes": "BranchPointStore",
       "density": 0.0292,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/civilization-memory-contract.md",
@@ -7922,10 +7840,10 @@
       "status": "draft",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "FailureBoundaryArchive / CounterexampleCommons 文明记忆层规范",
+      "describes": "文明记忆层对象规范",
       "density": 0,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/compile-promotion-contract.md",
@@ -7969,7 +7887,7 @@
       "describes": "CounterfactualScenario",
       "density": 0,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/coverage-matrix-contract.md",
@@ -8044,9 +7962,9 @@
       "kind": "contract",
       "legacy_kind": null,
       "describes": "HistoricalCompressionRecord",
-      "density": 0.0432,
+      "density": 0.0426,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/hypothesis-contract.md",
@@ -8065,10 +7983,10 @@
       "status": "draft",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "测试agent与代码编写agent的意图一致性审计协议",
+      "describes": "意图一致性审计协议",
       "density": 0.012,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/intent-alignment-report-template.md",
@@ -8110,9 +8028,9 @@
       "kind": "contract",
       "legacy_kind": null,
       "describes": "LineageCompileProposal",
-      "density": 0.043,
+      "density": 0.0426,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/mechanism-class-contract.md",
@@ -8222,7 +8140,7 @@
       "describes": "本体增量对象规范",
       "density": 0.0431,
       "errors": 0,
-      "warnings": 0
+      "warnings": 1
     },
     {
       "file": "docs/current/ontology-federation-contract.md",
@@ -8230,7 +8148,7 @@
       "status": "draft",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "OntologyModel / TranslationFunctor / ConflictSet 本体联邦规范",
+      "describes": "本体联邦对象规范",
       "density": 0,
       "errors": 0,
       "warnings": 1
@@ -8252,10 +8170,10 @@
       "status": "draft",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "ObserverModel / InstitutionModel 参与式自反世界规范",
+      "describes": "参与式自反世界规范",
       "density": 0,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/pipeline-contract.md",
@@ -8307,10 +8225,21 @@
       "status": "draft",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "PredictionError 驱动的模型修正提名对象",
+      "describes": "模型修正提名对象",
       "density": 0,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
+    },
+    {
+      "file": "docs/current/pruned-branch-record-contract.md",
+      "format": "md",
+      "status": "draft",
+      "kind": "contract",
+      "legacy_kind": null,
+      "describes": "PrunedBranchRecord",
+      "density": 0.0492,
+      "errors": 0,
+      "warnings": 0
     },
     {
       "file": "docs/current/reconstruction-contract.md",
@@ -8332,7 +8261,7 @@
       "describes": "ReconstructionStore",
       "density": 0.063,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/ref-algebra-contract.md",
@@ -8362,10 +8291,10 @@
       "status": "current",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "ProgramRevisionProposal 审查决策对象规范",
+      "describes": "审查决策对象规范",
       "density": 0,
       "errors": 0,
-      "warnings": 2
+      "warnings": 1
     },
     {
       "file": "docs/current/run-summary-contract.md",
@@ -8461,10 +8390,10 @@
       "status": "draft",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "OpenAGI级测试验证体系与运行时信息收集规范",
+      "describes": "测试验证策略规范",
       "density": 0.0145,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/transition-contract.md",
@@ -8483,10 +8412,10 @@
       "status": "draft",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "ProofLineage / ConstitutionalLayer 反射性文明引擎规范",
+      "describes": "反射性文明引擎规范",
       "density": 0,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/current/v6-world-model-contract.md",
@@ -8516,10 +8445,10 @@
       "status": "draft",
       "kind": "contract",
       "legacy_kind": null,
-      "describes": "MechanismProgram 有效域对象规范",
+      "describes": "有效域对象规范",
       "density": 0,
       "errors": 0,
-      "warnings": 1
+      "warnings": 0
     },
     {
       "file": "docs/external-integration.md",

--- a/causal-learner/mcp-server/src/core/pipeline.ts
+++ b/causal-learner/mcp-server/src/core/pipeline.ts
@@ -119,6 +119,13 @@ import type { HistoricalCompressionRecordStoreStats } from './historical-compres
 import { createHistoricalCompressionRecord } from './historical-compression-record.js';
 import { LineageCompileProposalStore } from './lineage-compile-proposal-store.js';
 import type { LineageCompileProposalStoreStats } from './lineage-compile-proposal-store.js';
+import { PrunedBranchRecordStore } from './pruned-branch-record-store.js';
+import type { PrunedBranchRecordStoreStats } from './pruned-branch-record-store.js';
+import {
+  createPrunedBranchRecord,
+  type PrunedBranchRecord,
+  type CreatePrunedBranchRecordInput,
+} from './pruned-branch-record.js';
 import {
   createLineageCompileProposal,
   approveProposal as approveLineageProposal,
@@ -205,6 +212,8 @@ export interface PipelineConfig {
   historicalCompressionRecordDbPath: string;
   /** LineageCompileProposal 持久化数据库路径 */
   lineageCompileProposalDbPath: string;
+  /** PrunedBranchRecord 持久化数据库路径（v13 G5：被剪掉的真实分支） */
+  prunedBranchRecordDbPath: string;
 }
 
 /** 提交观测的输入 */
@@ -396,6 +405,8 @@ export class CausalPipeline {
   readonly historicalCompressionRecords: HistoricalCompressionRecordStore;
   /** v13 LineageCompileProposal 谱系编译提案存储 */
   readonly lineageCompileProposals: LineageCompileProposalStore;
+  /** v13 PrunedBranchRecord 被剪掉的真实分支记录（G5） */
+  readonly prunedBranchRecords: PrunedBranchRecordStore;
 
   private rvBuilder: RegulationViewBuilder;
   private config: PipelineConfig;
@@ -434,6 +445,7 @@ export class CausalPipeline {
       presentSliceDbPath:             config.presentSliceDbPath             ?? ':memory:',
       historicalCompressionRecordDbPath: config.historicalCompressionRecordDbPath ?? ':memory:',
       lineageCompileProposalDbPath:      config.lineageCompileProposalDbPath      ?? ':memory:',
+      prunedBranchRecordDbPath:          config.prunedBranchRecordDbPath          ?? ':memory:',
     };
     this.config = resolved;
 
@@ -493,6 +505,7 @@ export class CausalPipeline {
     this.presentSlices = new PresentSliceStore(resolved.presentSliceDbPath);
     this.historicalCompressionRecords = new HistoricalCompressionRecordStore(resolved.historicalCompressionRecordDbPath);
     this.lineageCompileProposals = new LineageCompileProposalStore(resolved.lineageCompileProposalDbPath);
+    this.prunedBranchRecords = new PrunedBranchRecordStore(resolved.prunedBranchRecordDbPath);
 
     if (resolved.seedDefaults) {
       this.problemClasses.seedDefaults();
@@ -1548,6 +1561,30 @@ export class CausalPipeline {
   }
 
   // ===========================================================================
+  // v13 G5: 记录被剪掉的真实分支
+  // ===========================================================================
+
+  /**
+   * 记录一条被剪掉的真实分支（PrunedBranchRecord）
+   *
+   * v13 G5：失败不是目的，而是被剪掉的可能性空间。
+   * 每当一条分支因 failure / institution / design / physics 被 possibility space
+   * 剪掉，调用方应显式登记一条 PBR，保留"它曾经真实存在"的审计痕迹。
+   *
+   * 最小上游依赖：必须绑定到剪枝发生时的 PresentSlice ID，保证 lineage 可追溯。
+   *
+   * @param input 分支描述 + 剪枝理由 + PresentSliceRef 等（见 CreatePrunedBranchRecordInput）
+   * @returns 已持久化的 PrunedBranchRecord
+   */
+  recordPrunedBranch(
+    input: CreatePrunedBranchRecordInput,
+  ): { prunedBranchRecord: PrunedBranchRecord } {
+    const record = createPrunedBranchRecord(input);
+    this.prunedBranchRecords.save(record);
+    return { prunedBranchRecord: record };
+  }
+
+  // ===========================================================================
   // close
   // ===========================================================================
 
@@ -1585,6 +1622,7 @@ export class CausalPipeline {
     this.presentSlices.close();
     this.historicalCompressionRecords.close();
     this.lineageCompileProposals.close();
+    this.prunedBranchRecords.close();
     // rvBuilder 不拥有独立 DB 连接，无需单独关闭
   }
 

--- a/causal-learner/mcp-server/src/index.ts
+++ b/causal-learner/mcp-server/src/index.ts
@@ -944,6 +944,7 @@ export function buildPipelineConfig(baseDbPath: string): PipelineConfig {
     presentSliceDbPath:             withSuffix('present-slice'),
     historicalCompressionRecordDbPath: withSuffix('historical-compression-record'),
     lineageCompileProposalDbPath:     withSuffix('lineage-compile-proposal'),
+    prunedBranchRecordDbPath:         withSuffix('pruned-branch-record'),
   };
 }
 

--- a/causal-learner/mcp-server/src/tests/pipeline-pruned-branch.test.ts
+++ b/causal-learner/mcp-server/src/tests/pipeline-pruned-branch.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Pipeline × PrunedBranchRecord 集成测试
+ * contract: docs/current/pruned-branch-record-contract.md
+ *
+ * 验证 pipeline.recordPrunedBranch(input) 会：
+ *   1. 创建 PBR 并持久化到 prunedBranchRecords
+ *   2. 可通过 getByPresentSliceRef 反查
+ *   3. 校验不变量 PBR-1/2/3（空 branchDescription / 空 prunedBy / 空 presentSliceRef 抛出）
+ *   4. close() 后连接释放
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { CausalPipeline } from '../core/pipeline.js';
+
+describe('Pipeline × PrunedBranchRecord (v13 G5)', () => {
+  it('recordPrunedBranch 写入 PBR 且可按 presentSliceRef 反查', () => {
+    const pipeline = new CausalPipeline({ seedDefaults: false });
+
+    const { prunedBranchRecord } = pipeline.recordPrunedBranch({
+      branchDescription: '试图在 review rejected 之后继续 compile',
+      prunedBy: ['institution'],
+      presentSliceRef: 'PS_pipeline_001',
+      definingEpisodeIds: ['ep_x'],
+      rationale: 'review decision verdict=rejected',
+    });
+
+    assert.match(prunedBranchRecord.id, /^PBR_[a-f0-9]{12}$/);
+    assert.strictEqual(prunedBranchRecord.presentSliceRef, 'PS_pipeline_001');
+
+    const loaded = pipeline.prunedBranchRecords.get(prunedBranchRecord.id);
+    assert.ok(loaded);
+    assert.strictEqual(loaded!.branchDescription, '试图在 review rejected 之后继续 compile');
+
+    const bySlice = pipeline.prunedBranchRecords.getByPresentSliceRef('PS_pipeline_001');
+    assert.strictEqual(bySlice.length, 1);
+    assert.strictEqual(bySlice[0].id, prunedBranchRecord.id);
+
+    pipeline.close();
+  });
+
+  it('recordPrunedBranch 对空 branchDescription 抛 PBR-1', () => {
+    const pipeline = new CausalPipeline({ seedDefaults: false });
+    assert.throws(
+      () => pipeline.recordPrunedBranch({
+        branchDescription: '',
+        prunedBy: ['failure'],
+        presentSliceRef: 'PS_x',
+      }),
+      /PBR-1/,
+    );
+    pipeline.close();
+  });
+
+  it('recordPrunedBranch 对空 prunedBy 抛 PBR-2', () => {
+    const pipeline = new CausalPipeline({ seedDefaults: false });
+    assert.throws(
+      () => pipeline.recordPrunedBranch({
+        branchDescription: 'x',
+        prunedBy: [],
+        presentSliceRef: 'PS_x',
+      }),
+      /PBR-2/,
+    );
+    pipeline.close();
+  });
+
+  it('recordPrunedBranch 对空 presentSliceRef 抛 PBR-3', () => {
+    const pipeline = new CausalPipeline({ seedDefaults: false });
+    assert.throws(
+      () => pipeline.recordPrunedBranch({
+        branchDescription: 'x',
+        prunedBy: ['failure'],
+        presentSliceRef: '',
+      }),
+      /PBR-3/,
+    );
+    pipeline.close();
+  });
+
+  it('getStats 包含默认种子被剪记录为 0', () => {
+    const pipeline = new CausalPipeline({ seedDefaults: false });
+    const stats = pipeline.prunedBranchRecords.getStats();
+    assert.strictEqual(stats.totalCount, 0);
+    assert.strictEqual(stats.byReason.failure, 0);
+    pipeline.close();
+  });
+
+  it('多条不同 prunedBy 聚合到 byReason 正确', () => {
+    const pipeline = new CausalPipeline({ seedDefaults: false });
+    pipeline.recordPrunedBranch({
+      branchDescription: 'a',
+      prunedBy: ['failure'],
+      presentSliceRef: 'PS_agg',
+    });
+    pipeline.recordPrunedBranch({
+      branchDescription: 'b',
+      prunedBy: ['institution', 'design'],
+      presentSliceRef: 'PS_agg',
+    });
+    pipeline.recordPrunedBranch({
+      branchDescription: 'c',
+      prunedBy: ['physics'],
+      presentSliceRef: 'PS_agg',
+    });
+
+    const stats = pipeline.prunedBranchRecords.getStats();
+    assert.strictEqual(stats.totalCount, 3);
+    assert.strictEqual(stats.byReason.failure, 1);
+    assert.strictEqual(stats.byReason.institution, 1);
+    assert.strictEqual(stats.byReason.design, 1);
+    assert.strictEqual(stats.byReason.physics, 1);
+
+    const bySlice = pipeline.prunedBranchRecords.getByPresentSliceRef('PS_agg');
+    assert.strictEqual(bySlice.length, 3);
+
+    pipeline.close();
+  });
+});

--- a/docs/current/metamodel.md
+++ b/docs/current/metamodel.md
@@ -10,7 +10,20 @@ describes: "五模块核心语义定义"
 # BestQ-A 元模型：当前语义合同
 
 > 本文档是系统的**唯一语义底座**。所有代码、表结构、MCP 工具名必须与本文档对齐。
-> 不是 v6，而是 v1-v5 的收束。
+> 本文件原始范围是 v1-v5 的收束（五模块核心语义）。v6-v13 层在之上追加，不替换这里的五个对象。
+> **v6+ 追加层的合同不在此文件，见 §11.3 v6+ 扩展层索引** — 新增对象必须同时在对应的独立 `*-contract.md` 里定义。
+
+---
+
+## 0.5 v6+ 扩展层（非替换）
+
+五模块是本体论基底，v6-v13 在之上追加三类能力：
+
+- **执行闭环层（v6-v8）**：MechanismInstance / MechanismProgram / ReviewDecision / ValidityEnvelope / CounterfactualScenario / ExperimentDesign / ActionExecution / OutcomeRecord / PredictionError
+- **治理层（v9-v11）**：ProgramRevisionProposal / FailureBoundaryArchive / StateSnapshot / Transition
+- **历史生成层（v12-v13）**：AcceptedReconstruction（MSP）/ BranchPoint / PresentSlice / HistoricalCompressionRecord / LineageCompileProposal / **PrunedBranchRecord（G5 被剪分支）**
+
+这些对象**不改写五个基底**，只在闭环顶端给出 lineage、失败边界、谱系治理的审计面。具体 schema 与不变量见 `docs/current/*-contract.md` 与 `docs/design_history/v13_historical_generative_ontology.md`。
 
 ---
 
@@ -431,3 +444,26 @@ graph TD
 |------|------|------|
 | RefAlgebra 合同 | `current/ref-algebra-contract.md` | 复合规则、force 约束、evidencePolicy、proof 失效 |
 | Template 不变量合同 | `current/template-invariant-contract.md` | SlotFingerprint、InvariantCheck、模板生命周期、涌现治理 |
+
+### 11.3 v6+ 扩展层索引
+
+五模块基底之外的追加对象，SSOT 在各自独立合同里；本表只给索引，不重复 schema：
+
+| 对象 | 合同 | v 分层 |
+|------|------|--------|
+| MechanismInstance / MechanismClass / MechanismProgram | `current/mechanism-instance-contract.md`、`current/mechanism-class-contract.md`、`current/mechanism-program-contract.md` | v6 |
+| ReviewDecision | `current/review-decision-contract.md` | v6 |
+| ValidityEnvelope | `current/validity-envelope-contract.md` | v6 |
+| CounterfactualScenario / ExperimentDesign | `current/counterfactual-scenario-contract.md`、`current/experiment-design-contract.md` | v7 |
+| ActionExecution / OutcomeRecord / PredictionError | `current/action-execution-contract.md`、`current/outcome-record-contract.md`、`current/prediction-error-contract.md` | v7-v8 |
+| StateSnapshot / Transition | `current/state-snapshot-contract.md`、`current/transition-contract.md` | v9 |
+| ProgramRevisionProposal | `current/program-revision-proposal-contract.md` | v9 |
+| FailureBoundaryArchive | `current/civilization-memory-contract.md`、`current/v11-world-model-contract.md` | v11 |
+| AcceptedReconstruction（Minimal Sufficient Provenance） | `current/reconstruction-contract.md` | v12 |
+| BranchPoint | `current/branch-point-contract.md` | v12-v13 |
+| PresentSlice | `current/present-slice-contract.md` | v13 |
+| HistoricalCompressionRecord | `current/historical-compression-record-contract.md` | v13 |
+| LineageCompileProposal | `current/lineage-compile-proposal-contract.md` | v13 |
+| **PrunedBranchRecord（G5 被剪分支）** | `current/pruned-branch-record-contract.md` | v13 |
+
+更深的设计背景见 `design_history/v13_historical_generative_ontology.md`（根公理 G1-G6、谱系本体化完整论证）。


### PR DESCRIPTION
## 背景

继 #81 把 `PrunedBranchRecord`（PBR）作为独立对象 + store 落地之后，本 PR 完成 v13 G5 **"失败是被剪掉的可能性空间"** 的第二步：把 PBR 抬进 `CausalPipeline` 生命周期，并在 metamodel 里显式承认 v6-v13 追加层（否则 metamodel 仍停留在 v1-v5 的五模块语义，与实际代码拉开 7 个版本的差距）。

## 改动

### 1. pipeline 挂载 PBR Store

`causal-learner/mcp-server/src/core/pipeline.ts`
- 新增 `readonly prunedBranchRecords: PrunedBranchRecordStore` 字段
- `PipelineConfig.prunedBranchRecordDbPath` 配置项（默认 \`:memory:\`）
- 新增公共方法 \`pipeline.recordPrunedBranch(input)\`：调用 \`createPrunedBranchRecord\` + \`save\`，调用方拿回已持久化的 PBR
- \`close()\` 释放

**刻意最小**：只提供工厂 + save 封装，**不在 recordFix / rejectProposal 里自动触发**。剪枝语义要求调用方显式判断"是不是要把这条分支从 possibility space 剪掉"，不能由 pipeline 越俎代庖。

`causal-learner/mcp-server/src/index.ts`
- \`buildPipelineConfig\` 为 PBR 分配独立数据库文件路径（与其他 v13 对象同级）

### 2. 集成测试

`causal-learner/mcp-server/src/tests/pipeline-pruned-branch.test.ts`（新增）

6 项 pipeline 级集成测试（区别于 #81 的 store 级单元测试）：
- recordPrunedBranch 写入 + \`getByPresentSliceRef\` 反查
- PBR-1/2/3 三条不变量在 pipeline 入口处校验
- \`getStats\` 空状态 + 多 \`prunedBy\` 聚合正确

### 3. metamodel 升级到 v13

\`docs/current/metamodel.md\`
- **§0.5 v6+ 扩展层**（新增）：明确 v6-v13 在五模块基底**之上追加**，不替换；分三类：执行闭环层（v6-v8）/ 治理层（v9-v11）/ 历史生成层（v12-v13）
- **§11.3 v6+ 合同索引表**（新增）：14 个追加对象 → 独立 contract 文件的映射索引
- 顶部摘要从"不是 v6，而是 v1-v5 的收束"升级为"v6+ 追加层合同见 §11.3"

## 验证

- \`npm test\`: **337/337 通过**（新增 6 项 PBR pipeline 集成测试，原有 331 项全部 GREEN）
- \`contract-audit\`: **errors=0**；\`metamodel.md\` 本文件 \`errors=0 warnings=0\`

## 关系链

- **上游**: #81（PBR 合同 + store + 单元测试），#80（PresentSlice 等三对象入 pipeline）
- **下游**: 未来把 \`recordPrunedBranch\` 接入 ReviewDecision=rejected / MechanismProgram.failsWhen 触发路径，让剪枝自动审计而非手动登记
- **v13 G5**: 本 PR 完成"PBR 从抽象合同到可在真实 pipeline 里登记"的最后一公里

🤖 Generated with [Claude Code](https://claude.com/claude-code)