### PR TITLE
docs: record ClearLoop product split

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,5 @@ BestQ-A 当前应被理解为一个以证据驱动的 world modeling / reasoning
 
 - `docs/records/2026-05-10-relevance-to-causality.md`：定义“因果性，是被结构化后可复用的相关性”。
 - `docs/records/2026-05-10-codesail-repo-split.md`：记录 VS Code 产品从旧 CodeSail 原型拆分并命名为 ClearLoop。
+- `docs/records/2026-05-10-session-refactoring.md`：定义如何把一次 AI/CLI session 重构为可复用的 Best Question、Best Answer 与 causal pattern。
 - `specs/006-vscode-explicit-reasoning-control-plane.md`：描述 BestQ-A 与 ClearLoop 组合成显式推理控制面的下一步切片。

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ BestQ-A 当前应被理解为一个以证据驱动的 world modeling / reasoning
 
 ## 当前系统如何工作
 
+长期产品目标：做一个免费开源、local-first、无默认遥测的 **Clear AI for controlled software engineering** VS Code 插件，让 AI coding agent 的计划、证据、执行、验证和记忆都变得可见、可控、可复用。
+
 系统的现行结构可概括为四层：
 
 - **接口层**：对外暴露工具、兼容接口与调用入口。
@@ -70,3 +72,9 @@ BestQ-A 当前应被理解为一个以证据驱动的 world modeling / reasoning
 - 先区分 **当前 contract** 与 **历史地平线**：前者看 `docs/current/`，后者看 `docs/design_history/`。
 - 先用语义对象理解系统，再用版本名理解其来源；不要直接从 `v8-v11` 倒推现状。
 - 任何超出 `docs/current/` 已收敛合同的表述，都应默认视为设计方向，而不是当前能力声明。
+
+## ClearLoop 产品记录
+
+- `docs/records/2026-05-10-relevance-to-causality.md`：定义“因果性，是被结构化后可复用的相关性”。
+- `docs/records/2026-05-10-codesail-repo-split.md`：记录 VS Code 产品从旧 CodeSail 原型拆分并命名为 ClearLoop。
+- `specs/006-vscode-explicit-reasoning-control-plane.md`：描述 BestQ-A 与 ClearLoop 组合成显式推理控制面的下一步切片。

--- a/docs/records/2026-05-10-codesail-repo-split.md
+++ b/docs/records/2026-05-10-codesail-repo-split.md
@@ -1,0 +1,68 @@
+---
+event: codesail-repo-split
+recorded_at: 2026-05-10T00:00:00+08:00
+immutable: true
+---
+
+# ClearLoop Repo Split
+
+## Decision
+
+The VS Code product is no longer treated as an embedded external directory inside BestQ-A.
+
+It was first split under the prototype name CodeSail, then renamed to ClearLoop:
+
+```text
+E:\1_agents_space\9_AGI\ClearLoop
+```
+
+Previous location:
+
+```text
+E:\1_agents_space\9_AGI\BestQ-A\external\CodeSail
+```
+
+## Why
+
+BestQ-A and ClearLoop now have different ownership boundaries.
+
+BestQ-A should remain the reasoning, memory, retrieval, causal-learning, MCP, and CLI core.
+
+ClearLoop should be the user-facing VS Code product:
+
+- extension UI;
+- Rust local backend;
+- CLI agent orchestration;
+- Codex CLI / Claude Code CLI handoff scaffolds;
+- install, package, smoke, and Marketplace lifecycle.
+
+Keeping the VS Code product under `external/` made the BestQ-A worktree noisy and blurred product responsibilities.
+
+## Contract Between Projects
+
+The shared product loop is:
+
+```text
+task -> explicit plan -> controlled agent run -> captured evidence -> verification -> memory gate
+```
+
+The first concrete interchange format is the local handoff directory:
+
+```text
+<workspace>/.bestqa/agent-runs/<run>/
+  handoff.md
+  manifest.json
+  README.md
+  result.md
+```
+
+ClearLoop owns creating and displaying this run scaffold.
+
+BestQ-A owns future reasoning/memory/retrieval semantics that can consume or promote verified run records.
+
+## Immediate Follow-Up
+
+- Keep BestQ-A docs pointing to `../ClearLoop`, not `external/CodeSail`.
+- Keep ClearLoop product documentation and VS Code validation inside the ClearLoop repository.
+- Define the `.bestqa/agent-runs` schema before adding automatic execution adapters.
+- Do not re-embed ClearLoop as a nested repo unless there is a deliberate monorepo decision.

--- a/docs/records/2026-05-10-relevance-to-causality.md
+++ b/docs/records/2026-05-10-relevance-to-causality.md
@@ -1,0 +1,55 @@
+---
+event: relevance-to-causality-product-definition
+recorded_at: 2026-05-10T00:00:00+08:00
+immutable: true
+---
+
+# Relevance to Causality
+
+## Definition
+
+BestQ-A and ClearLoop use this product definition:
+
+```text
+causality = structured, reusable relevance
+```
+
+In Chinese:
+
+```text
+因果性，是被结构化后可复用的相关性。
+```
+
+AI is strong at producing relevance. It can connect symptoms, files, commands, APIs, prior cases, and plausible fixes. But relevance alone is not yet an engineering object. It is hard to inspect, control, verify, or reuse.
+
+Causality is the next layer: relevance made concrete, clear, structured, evidence-bearing, and stable enough to be reused.
+
+## Homomorphism Claim
+
+The structure is not decoration. It is an attempted homomorphism from real correlations in the world into software objects:
+
+```text
+real-world correlation
+  -> observed evidence
+  -> causal hypothesis
+  -> action
+  -> outcome
+  -> verification
+  -> reusable memory
+```
+
+The better this mapping is, the more reliably the system can improve itself.
+
+## Product Split
+
+BestQ-A owns the reasoning, memory, retrieval, causal-learning, MCP, and CLI semantics.
+
+ClearLoop owns the human-facing VS Code control plane:
+
+- make AI relevance visible;
+- organize it into explicit causal work records;
+- run Codex CLI / Claude Code CLI through auditable handoffs;
+- capture evidence, outputs, diffs, logs, and verification;
+- promote only verified lessons into reusable memory.
+
+The product goal is not to expose hidden model chain-of-thought. The goal is to combine implicit model intelligence with explicit causal state so humans can control, correct, and steadily improve the system.

--- a/docs/records/2026-05-10-session-refactoring.md
+++ b/docs/records/2026-05-10-session-refactoring.md
@@ -1,0 +1,113 @@
+---
+event: session-refactoring-product-definition
+recorded_at: 2026-05-10T00:00:00+08:00
+immutable: true
+---
+
+# Session Refactoring
+
+## Definition
+
+A completed AI or CLI session is raw material. It is comparable to a large source file that solved one goal but still mixes together problem definition, exploration, false starts, useful commands, evidence, implementation, tests, and final conclusions.
+
+BestQ-A should not treat that raw session as the reusable unit. It should refactor the session into smaller, named, evidence-backed assets:
+
+```text
+raw AI/CLI session
+  -> BestQuestion
+  -> BestAnswer
+  -> ContextFilter
+  -> PlanPattern
+  -> EvidencePath
+  -> VerificationRecipe
+  -> CausalPattern
+```
+
+In Chinese:
+
+```text
+Session Refactoring = 把一次不可复用的 AI/CLI 工作过程，重构成可复用的问题、答案、计划、证据、验收方法和因果模式。
+```
+
+## Code Analogy
+
+```text
+large code file
+  -> functions
+  -> modules
+  -> interfaces
+  -> tests
+  -> reusable library
+
+AI/CLI session
+  -> questions
+  -> answers
+  -> context filters
+  -> plans
+  -> evidence
+  -> verification recipes
+  -> causal patterns
+  -> reusable memory
+```
+
+This analogy matters because a transcript is not yet knowledge. A transcript is a trace. Knowledge begins when the trace is split into reusable, testable, named parts.
+
+## Product Split
+
+ClearLoop captures and controls the work session:
+
+- user intent;
+- handoff;
+- plan;
+- agent execution;
+- commands;
+- diffs;
+- logs;
+- verification;
+- final result.
+
+BestQ-A distills the verified run into reusable knowledge:
+
+- best way to ask the recurring problem;
+- best answer under known context;
+- which evidence matters;
+- which verification proves the fix;
+- which causal pattern can be reused.
+
+## Best Question And Answer
+
+The target reusable object is not a chat message. It is closer to:
+
+```text
+BestQuestion:
+In <context>, how should we diagnose <problem shape>?
+
+BestAnswer:
+Inspect <evidence path>. If <signal> appears, prefer <strategy>.
+Verify with <verification recipe>. Do not reuse when <exception> holds.
+```
+
+This makes the name BestQ-A sharper: it is a system for deriving best questions and best answers from real verified work, not a generic Q&A notebook.
+
+## Memory Gate
+
+A session-derived asset can be promoted only if:
+
+- it has a clear problem shape;
+- the reusable context is explicit;
+- evidence is linked back to the original run;
+- verification passed or residual risk was accepted by a human;
+- exceptions and failure cases are recorded.
+
+Otherwise it should remain local run evidence, not reusable memory.
+
+## Strategic Meaning
+
+This is the bridge between the two repositories:
+
+```text
+ClearLoop = capture, control, and verify AI work
+BestQ-A   = refactor verified work into reusable questions, answers, and causal memory
+```
+
+The goal is stable improvement. Each completed run should make the next similar run easier to frame, cheaper to execute, and safer to trust.

--- a/specs/006-vscode-explicit-reasoning-control-plane.md
+++ b/specs/006-vscode-explicit-reasoning-control-plane.md
@@ -1,0 +1,110 @@
+# Spec 006: VS Code Explicit Reasoning Control Plane
+
+## Source
+
+`docs/records/2026-05-10-explicit-implicit-reasoning-control-plane.md`.
+
+## Goal
+
+Turn BestQ-A plus the sibling ClearLoop VS Code project into one product loop:
+
+```text
+Task -> explicit plan -> controlled agent run -> captured evidence -> verification -> memory gate
+```
+
+This spec is about the VS Code / agent-runtime product bridge. It does not change BestQ-A core ontology rules directly.
+
+## Product Principle
+
+Use implicit LLM reasoning for generation and synthesis.
+
+Use explicit BestQ-A objects for control, audit, replay, and memory.
+
+The UI must show structured reasoning state, not hidden chain-of-thought.
+
+## Boundary
+
+```text
+bestqa-core:
+  semantic identity, evidence, RefAlgebra, memory, retrieval, promotion
+
+agent-runtime:
+  start/monitor/cancel Codex CLI, Claude Code CLI, and future agents
+
+VS Code extension:
+  human control plane and visual state
+
+external providers:
+  implicit reasoning and code generation candidates
+```
+
+## Required Data Objects
+
+Minimum runtime objects:
+
+- `TaskRecord`
+- `PlanRecord`
+- `PlanStep`
+- `ActionExecution`
+- `AgentProcess`
+- `ExecutionArtifact`
+- `VerificationResult`
+- `MemoryPromotionDecision`
+
+Each code-changing execution must include:
+
+- command;
+- cwd;
+- provider/model;
+- sandbox/permission mode;
+- start/end timestamps;
+- stdout/stderr or session log path;
+- produced diff or explicit no-diff result;
+- verification commands and outputs;
+- exit/cancel status;
+- memory promotion decision.
+
+## Requirements
+
+- Add a single product contract for agent execution records before expanding UI features.
+- Make ClearLoop YOLO execution call a real agent runtime, not just `start_execution` metadata.
+- Support at least two launch adapters:
+  - Codex CLI through `codex exec`;
+  - Claude Code through non-interactive print or plugin command mode.
+- Capture produced diffs after the run.
+- Capture verification command outputs.
+- Persist an `ActionExecution`-like record into BestQ-A or a clearly named bridge store.
+- Surface the run in VS Code as structured state: planned, running, verifying, failed, succeeded, promoted/skipped.
+- Keep hidden model chain-of-thought out of persisted product artifacts.
+- Persist only structured summaries, evidence, tool events, diffs, and verification outputs.
+- Provide a manual approval gate before promoting a run into long-term memory.
+
+## Non-Goals
+
+- Do not rewrite BestQ-A core.
+- Do not expose hidden chain-of-thought.
+- Do not build a full symbolic planner before the runtime loop exists.
+- Do not claim autonomous self-maintenance until diff capture and verification are real.
+- Do not treat Traycer visual parity as sufficient product progress.
+
+## Acceptance Criteria
+
+- [ ] A single local command can start a Codex CLI run for a small fixture task and return an execution record.
+- [ ] The execution record contains command, cwd, timestamps, model/provider, exit status, log path, and diff path.
+- [ ] A failed verification is recorded as a failed outcome, not as an invisible chat failure.
+- [ ] A successful run can be reviewed and either promoted or skipped for memory.
+- [ ] VS Code can display the same execution state without inventing a second schema.
+- [ ] The Claude adapter can run in dry-run or smoke mode without MCP.
+- [ ] Documentation clearly distinguishes implicit model output from explicit BestQ-A state.
+
+## Suggested First Slice
+
+1. Define the execution record schema in docs and one runtime module.
+2. Implement Codex CLI adapter first because the sibling `../ClearLoop` project already has a `CodexProvider` and CLI handoff scaffold.
+3. Run one fixture task in a temp workspace.
+4. Capture `git diff`, stdout/stderr/session log, and verification output.
+5. Add VS Code display after the CLI record is stable.
+
+## Output When Complete
+
+`<promise>DONE</promise>`


### PR DESCRIPTION
## Summary
- record ClearLoop as the sibling VS Code control-plane project
- define causality as structured, reusable relevance
- add the next VS Code explicit-reasoning control-plane spec
- link the new ClearLoop records from the README

## Verification
- docs-only change
- conflict markers checked with rg
- git diff --cached --check passed before commit